### PR TITLE
Swagger 의존성 추가 및 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     // Spring Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
+
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/dnd/reetplace/app/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/reetplace/app/config/SecurityConfig.java
@@ -9,14 +9,16 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
+import java.util.Arrays;
+
 @Slf4j
 @RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {
 
     private static final String BASE_URL = "/api";
-    private static final String[] AUTH_WHITELIST = {
-            "/api/health/**"
+    private static final String[] AUTH_WHITE_LIST = {
+            // TODO: 추후 로그인 권한이 필요하지 않은 API의 uri 기입
     };
 
     @Bean
@@ -26,10 +28,14 @@ public class SecurityConfig {
                 .csrf().disable()
                 .formLogin().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                        .antMatchers(AUTH_WHITELIST).permitAll()
-                        .anyRequest().authenticated()
+                .authorizeHttpRequests(auth -> {
+                            auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                                    .mvcMatchers("/swagger-ui/**", "/v3/api-docs/**", "/actuator/**").permitAll();
+                            Arrays.stream(AUTH_WHITE_LIST)
+                                    .forEach(authWhiteListElem ->
+                                            auth.mvcMatchers(BASE_URL + authWhiteListElem).permitAll());
+                            auth.anyRequest().authenticated();
+                        }
                 )
                 .build();
     }

--- a/src/main/java/com/dnd/reetplace/app/config/SwaggerConfig.java
+++ b/src/main/java/com/dnd/reetplace/app/config/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package com.dnd.reetplace.app.config;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI reetPlaceApi(@Value("reet-place.app.version") String appVersion) {
+        // TODO: 로그인 기능 구현 후 Swagger에서 access-token을 header에 첨부할 수 있도록 security scheme component 추가 필요.
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("Reet-Place API Docs")
+                                .description("DND 8기 2조 앱 프로젝트 Reet-Place의 API 명세서")
+                                .version(appVersion)
+                )
+                .externalDocs(
+                        new ExternalDocumentation()
+                                .description("Team Reet-Place GitHub Repository")
+                                .url("https://github.com/dnd-side-project/dnd-8th-2-backend")
+                );
+    }
+}

--- a/src/main/java/com/dnd/reetplace/global/log/LogUtils.java
+++ b/src/main/java/com/dnd/reetplace/global/log/LogUtils.java
@@ -6,17 +6,17 @@ import java.util.UUID;
 
 public class LogUtils {
 
-    public static final String LOG_TRACE_ID = "ReetPlaceLogTraceId";
+    public static final String LOG_TRACE_ID_MDC_KEY = "ReetPlaceLogTraceId";
 
     public static String getLogTraceId() {
-        return MDC.get(LOG_TRACE_ID);
+        return MDC.get(LOG_TRACE_ID_MDC_KEY);
     }
 
     public static void setLogTraceId() {
-        MDC.put(LOG_TRACE_ID, UUID.randomUUID().toString().substring(0, 8));
+        MDC.put(LOG_TRACE_ID_MDC_KEY, UUID.randomUUID().toString().substring(0, 8));
     }
 
     public static void removeLogTraceId() {
-        MDC.remove(LOG_TRACE_ID);
+        MDC.remove(LOG_TRACE_ID_MDC_KEY);
     }
 }

--- a/src/main/java/com/dnd/reetplace/global/log/filter/LogApiInfoFilter.java
+++ b/src/main/java/com/dnd/reetplace/global/log/filter/LogApiInfoFilter.java
@@ -23,6 +23,11 @@ import static com.dnd.reetplace.global.log.LogUtils.*;
 @Component
 public class LogApiInfoFilter extends OncePerRequestFilter {
 
+    private static final String[] LOG_BLACK_LIST = {
+            "/swagger",
+            "/v3/api-docs"
+    };
+
     private static final List<MediaType> VISIBLE_TYPES = Arrays.asList(
             MediaType.valueOf("text/*"),
             MediaType.APPLICATION_FORM_URLENCODED,
@@ -55,11 +60,13 @@ public class LogApiInfoFilter extends OncePerRequestFilter {
             ContentCachingResponseWrapper response,
             FilterChain filterChain
     ) throws IOException, ServletException {
+        boolean doLog = Arrays.stream(LOG_BLACK_LIST).noneMatch(request.getRequestURI()::contains);
+
         try {
-            logRequest(request);
+            if (doLog) logRequest(request);
             filterChain.doFilter(request, response);
         } finally {
-            logResponse(response);
+            if (doLog) logResponse(response);
             response.copyBodyToResponse();
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,4 @@
-reet-place.application.version: v.0.0.1
+reet-place.app.version: v.0.0.1
 
 logging:
   level:


### PR DESCRIPTION
## 🔥 Related Issue
- #14
  - 로그인 기능이 구현된 후 access-token에 대한 설정을 추가해야 하는 작업이 아직 남았기 때문에 issue를 아직 닫지 않는다.

## 🏃‍ Task
- Swagger 의존성 추가 및 API 명세서 설정 작성
  - Swagger-ui 페이지에 접근할 때 대량의 html 내용이 로그에 찍히는 것을 보고 조치함. Swagger-ui 관련한 요청/응답은 로그에 남지 않음.
  - `SpringSecurity`에 Swagger 관련 문서 접근을 허용하도록 설정 추가 및 일부 코드 변경 (`BASE_URL`을 활용하도록)
- API 요청/응답 logging 로직 수정
  - Request, response 모두 한 줄로 출력되도록 수정.
  - Content-type이 `text/html`, `text,css`, `multipart/form-data`인 경우에 대한 API 요청/응답 format 정의
  - 수정한 내용을 바탕으로 출력되는 로그를 확인해보면 다음과 같다.
    <img width="1647" alt="스크린샷 2023-02-18 23 47 43" src="https://user-images.githubusercontent.com/60748900/219872940-40a0d8ff-7c95-4055-86d2-c4a075f329d7.png">
- LogBack MDC 데이터를 담을 때 사용하던 key값의 상수명 변경 (`LOG_TRACE_ID` -> `LOG_TRACE_ID_MDC_KEY`) 

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?