### PR TITLE
Error 응답 데이터 변경 - Validation Exception

### DIFF
--- a/src/main/java/com/dnd/reetplace/global/exception/GlobalExceptionType.java
+++ b/src/main/java/com/dnd/reetplace/global/exception/GlobalExceptionType.java
@@ -1,5 +1,6 @@
 package com.dnd.reetplace.global.exception;
 
+import com.dnd.reetplace.global.exception.type.ValidationErrorCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -18,20 +19,23 @@ import java.util.Optional;
  * <br>직접 정의한, {@link CustomException}을 상속받은 exception에 대한 정보는 {@link CustomExceptionType}에 작성하도록 한다.
  *
  * <ul>
- *     <li>1000 ~ 1299: 일반 예외. 아래 항목에 해당하지 않는 대부분의 예외가 여기에 해당한다</li>
+ *     <li>1000 ~ 1999: 일반 예외. 아래 항목에 해당하지 않는 대부분의 예외가 여기에 해당한다</li>
+ *     <li>120X: Validation 관련 예외</li>
+ *     <li>1210 ~ 1299: 구체적인 Validation content에 대한 exception. 해당 내용은 {@link ValidationErrorCode}, {@link GlobalExceptionHandler} 참고)</li>
  *     <li>13XX: API/Controller 관련 예외</li>
  *     <li>14XX: DB 관련 예외</li>
  * </ul>
  *
  * @see CustomExceptionType
+ * @see ValidationErrorCode
  */
 @Slf4j
 @Getter
 public enum GlobalExceptionType {
 
     UNHANDLED(1000, "알 수 없는 서버 에러가 발생했습니다."),
-    METHOD_ARGUMENT_NOT_VALID(1001, "요청 데이터가 잘못되었습니다.", MethodArgumentNotValidException.class),
-    CONSTRAINT_VIOLATION(1002, "요청 데이터가 잘못되었습니다.", ConstraintViolationException.class),
+    METHOD_ARGUMENT_NOT_VALID(1200, "요청 데이터가 잘못되었습니다.", MethodArgumentNotValidException.class),
+    CONSTRAINT_VIOLATION(1201, "요청 데이터가 잘못되었습니다.", ConstraintViolationException.class),
     HTTP_MESSAGE_NOT_READABLE(1300, "처리할 수 없는 요청입니다. 요청 정보가 잘못되지는 않았는지 확인해주세요.", HttpMessageNotReadableException.class),
     HTTP_REQUEST_METHOD_NOT_SUPPORTED(1301, "지원하지 않는 요청 방식입니다.", HttpRequestMethodNotSupportedException.class),
     HTTP_MEDIA_TYPE_NOT_ACCEPTABLE(1302, "Client에서 허용된 응답을 만들어 낼 수 없습니다.", HttpMediaTypeNotAcceptableException.class),

--- a/src/main/java/com/dnd/reetplace/global/exception/ValidationErrorDetails.java
+++ b/src/main/java/com/dnd/reetplace/global/exception/ValidationErrorDetails.java
@@ -1,0 +1,8 @@
+package com.dnd.reetplace.global.exception;
+
+public record ValidationErrorDetails(
+        Integer code,
+        String field,
+        String message
+) {
+}

--- a/src/main/java/com/dnd/reetplace/global/exception/ValidationErrorResponse.java
+++ b/src/main/java/com/dnd/reetplace/global/exception/ValidationErrorResponse.java
@@ -1,0 +1,10 @@
+package com.dnd.reetplace.global.exception;
+
+import java.util.List;
+
+public record ValidationErrorResponse(
+        Integer code,
+        String message,
+        List<ValidationErrorDetails> errors
+) {
+}

--- a/src/main/java/com/dnd/reetplace/global/exception/type/ValidationErrorCode.java
+++ b/src/main/java/com/dnd/reetplace/global/exception/type/ValidationErrorCode.java
@@ -1,0 +1,58 @@
+package com.dnd.reetplace.global.exception.type;
+
+import lombok.Getter;
+
+@Getter
+public enum ValidationErrorCode {
+    AssertFalse,
+    AssertTrue,
+    DecimalMax,
+    DecimalMin,
+    Digits,
+    Email,
+    Future,
+    FutureOrPresent,
+    Max,
+    Min,
+    Negative,
+    NegativeOrZero,
+    NotBlank,
+    NotEmpty,
+    NotNull,
+    Null,
+    Past,
+    PastOrPresent,
+    Pattern,
+    Positive,
+    PositiveOrZero,
+    Size,
+    DurationMax,
+    DurationMin,
+    CodePointLength,
+    ConstraintComposition,
+    CreditCardNumber,
+    Currency,
+    EAN,
+    ISBN,
+    Length,
+    Range,
+    UniqueElements,
+    URL;
+
+    /**
+     * 이 수치는 {@code GlobalExceptionType} 참고
+     *
+     * @see com.dnd.reetplace.global.exception.GlobalExceptionType
+     */
+    private static final int VALIDATION_EX_BASE_CODE = 1210;
+
+    /**
+     * Parameter로 전달된 name에 일치하는 validation error를 찾고 해당하는 application error code를 return한다.
+     *
+     * @param name validation error ({@code ValidationErrorCode} enum class의 constant 중 하나)
+     * @return parameter로 전돨된 name에 해당하는 validation error의 application error code
+     */
+    public static Integer getErrorCode(String name) {
+        return VALIDATION_EX_BASE_CODE + valueOf(name).ordinal();
+    }
+}

--- a/src/main/java/com/dnd/reetplace/global/exception/util/ViolationMessageResolver.java
+++ b/src/main/java/com/dnd/reetplace/global/exception/util/ViolationMessageResolver.java
@@ -1,0 +1,44 @@
+package com.dnd.reetplace.global.exception.util;
+
+import com.dnd.reetplace.global.exception.type.ValidationErrorCode;
+import lombok.AllArgsConstructor;
+
+import javax.validation.ConstraintViolation;
+
+@AllArgsConstructor
+public class ViolationMessageResolver {
+
+    private final ConstraintViolation<?> violation;
+
+    /**
+     * {@code violation}에 해당하는 application error code를 return한다.
+     *
+     * @return violation에 해당하는 application error code
+     */
+    public Integer getErrorCode() {
+        return ValidationErrorCode.getErrorCode(
+                violation.getConstraintDescriptor()
+                        .getAnnotation().annotationType().getSimpleName()
+        );
+    }
+
+    /**
+     * Violation exception이 발생한 filed의 filed name을 return한다.
+     *
+     * @return Violation exception이 발생한 filed의 filed name
+     */
+    public String getFieldName() {
+        String propertyPath = violation.getPropertyPath().toString();
+        int dotIdx = propertyPath.lastIndexOf(".");
+        return propertyPath.substring(dotIdx + 1);
+    }
+
+    /**
+     * 발생한 violation exception의 message(설명)을 return한다.
+     *
+     * @return 발생한 violation exception의 message(설명)
+     */
+    public String getMessage() {
+        return violation.getMessage();
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #18 

## 🏃‍ Task
- 기존에 validation exception이 발생했을 때는 error response가 좀 빈약했다. 이에 이번 commit을 통해 validation exception이 발생했을 때 왜 error가 발생헀는지 쉽게 알 수 있도록 자세한 내용을 응답으로 전달하도록 하였음.
- 이 PR을 적용하면 발생한 validation exception에 대해 response가 다음과 같이 return된다. 
  ```json
  {
      "code": 1201,
      "message": "요청 데이터가 잘못되었습니다.",
      "errors": [
          {
              "code": 1240,
              "field": "param2",
              "message": "길이가 3에서 10 사이여야 합니다"
          },
          {
              "code": 1222,
              "field": "param1",
              "message": "공백일 수 없습니다"
          }
      ]
  }
  ```
  각 field에 대한 설명은 다음과 같다.
  - `code`: application error code.
  - `message`: 발생한 error에 대한 설명.
  - `errors`: 여러 개의 validation exception이 한 번에 발생할 수 있으므로 발생한 모든 validation exception에 대한 상세 정보를 담고 있는 field.
  - `errors.field`: validation exception이 발생한 field name.

## 📄 Reference
- `MethodArgumentNotValidException`과 `ConstraintViolationException`에서 필요한 정보 추출하는 방법 - [Spring Boot Bean Validation 제대로 알고 쓰자](https://kapentaz.github.io/spring/Spring-Boo-Bean-Validation-%EC%A0%9C%EB%8C%80%EB%A1%9C-%EC%95%8C%EA%B3%A0-%EC%93%B0%EC%9E%90/#)
- Spring Validation annotation 목록 - [Spring Validation Annotation 총정리](https://hyeran-story.tistory.com/81)

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?