### PR TITLE
Swagger 의존성 추가 및 설정 -  Access token 관련 설정

### DIFF
--- a/src/main/java/com/dnd/reetplace/app/config/SwaggerConfig.java
+++ b/src/main/java/com/dnd/reetplace/app/config/SwaggerConfig.java
@@ -1,8 +1,10 @@
 package com.dnd.reetplace.app.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +26,16 @@ public class SwaggerConfig {
                         new ExternalDocumentation()
                                 .description("Team Reet-Place GitHub Repository")
                                 .url("https://github.com/dnd-side-project/dnd-8th-2-backend")
+                )
+                .components(
+                        new Components()
+                                .addSecuritySchemes(
+                                        "Authorization",
+                                        new SecurityScheme()
+                                                .type(SecurityScheme.Type.HTTP)
+                                                .scheme("Bearer")
+                                                .bearerFormat("JWT")
+                                )
                 );
     }
 }

--- a/src/main/java/com/dnd/reetplace/app/controller/AuthController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/AuthController.java
@@ -41,7 +41,6 @@ public class AuthController {
             description = "Refresh Token을 통해 Access Token, Refresh Token을 재발급합니다.",
             security = @SecurityRequirement(name = "Authorization")
     )
-    @Parameter(name = "Authorization", description = "사용자의 Refresh Token", example = "Bearer eyJ0eXAi...")
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(HttpServletRequest request) {
         return ResponseEntity.ok(oAuth2Service.refresh(request));

--- a/src/main/java/com/dnd/reetplace/app/controller/AuthController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/AuthController.java
@@ -5,7 +5,7 @@ import com.dnd.reetplace.app.dto.auth.response.TokenResponse;
 import com.dnd.reetplace.app.service.OAuth2Service;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,21 +24,24 @@ public class AuthController {
 
     private final OAuth2Service oAuth2Service;
 
-    @Operation(summary = "카카오 로그인", description = "카카오 서버에서 받은 Access Token을 통해 로그인을 진행합니다.")
-    @Parameter(
-            name = "access-token", description = "카카오 서버에서 받은 Access Token", in = ParameterIn.HEADER,
-            required = true, example = "29WryM8Px6..."
+    @Operation(
+            summary = "카카오 로그인",
+            description = "카카오 서버에서 받은 Access Token을 통해 로그인을 진행합니다."
     )
     @PostMapping("/login/kakao")
-    public ResponseEntity<LoginResponse> kakaoLogin(@RequestHeader("access-token") String token) {
+    public ResponseEntity<LoginResponse> kakaoLogin(
+            @Parameter(name = "access-token", description = "카카오 서버에서 받은 Access Token", example = "29WryM8Px6...")
+            @RequestHeader("access-token") String token
+    ) {
         return ResponseEntity.ok(oAuth2Service.kakaoLogin(token));
     }
 
-    @Operation(summary = "토큰 재발급", description = "Refresh Token을 통해 Access Token, Refresh Token을 재발급합니다.")
-    @Parameter(
-            name = "Authorization", description = "사용자의 Refresh Token", in = ParameterIn.HEADER,
-            required = true, example = "Bearer eyJ0eXAi..."
+    @Operation(
+            summary = "토큰 재발급",
+            description = "Refresh Token을 통해 Access Token, Refresh Token을 재발급합니다.",
+            security = @SecurityRequirement(name = "Authorization")
     )
+    @Parameter(name = "Authorization", description = "사용자의 Refresh Token", example = "Bearer eyJ0eXAi...")
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(HttpServletRequest request) {
         return ResponseEntity.ok(oAuth2Service.refresh(request));

--- a/src/main/java/com/dnd/reetplace/app/controller/AuthController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/AuthController.java
@@ -3,6 +3,9 @@ package com.dnd.reetplace.app.controller;
 import com.dnd.reetplace.app.dto.auth.response.LoginResponse;
 import com.dnd.reetplace.app.dto.auth.response.TokenResponse;
 import com.dnd.reetplace.app.service.OAuth2Service;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +22,16 @@ public class AuthController {
 
     private final OAuth2Service oAuth2Service;
 
+    @Operation(
+            summary = "카카오 로그인",
+            description = "카카오 서버에서 받은 Access Token을 통해 로그인을 진행합니다.<br>" +
+                    "로그인 성공 시, 사용자의 프로필 정보와 Access Token, Refresh Token이 반환됩니다.")
+    @Parameter(
+            name = "access-token",
+            description = "카카오 서버에서 받은 Access Token",
+            in = ParameterIn.HEADER,
+            example = "29WryM8Px69a4NB8VAX9wzPat9f46Meap24--OoCiolkAAAAYZ3tWXj"
+    )
     @PostMapping("/login/kakao")
     public ResponseEntity<LoginResponse> kakaoLogin(@RequestHeader("access-token") String token) {
         return ResponseEntity.ok(oAuth2Service.kakaoLogin(token));

--- a/src/main/java/com/dnd/reetplace/app/controller/AuthController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.dnd.reetplace.app.service.OAuth2Service;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,25 +19,26 @@ import javax.servlet.http.HttpServletRequest;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @RestController
+@Tag(name = "인증", description = "로그인, 회원가입, 토큰 재발급 등 인증 관련 API입니다.")
 public class AuthController {
 
     private final OAuth2Service oAuth2Service;
 
-    @Operation(
-            summary = "카카오 로그인",
-            description = "카카오 서버에서 받은 Access Token을 통해 로그인을 진행합니다.<br>" +
-                    "로그인 성공 시, 사용자의 프로필 정보와 Access Token, Refresh Token이 반환됩니다.")
+    @Operation(summary = "카카오 로그인", description = "카카오 서버에서 받은 Access Token을 통해 로그인을 진행합니다.")
     @Parameter(
-            name = "access-token",
-            description = "카카오 서버에서 받은 Access Token",
-            in = ParameterIn.HEADER,
-            example = "29WryM8Px69a4NB8VAX9wzPat9f46Meap24--OoCiolkAAAAYZ3tWXj"
+            name = "access-token", description = "카카오 서버에서 받은 Access Token", in = ParameterIn.HEADER,
+            required = true, example = "29WryM8Px6..."
     )
     @PostMapping("/login/kakao")
     public ResponseEntity<LoginResponse> kakaoLogin(@RequestHeader("access-token") String token) {
         return ResponseEntity.ok(oAuth2Service.kakaoLogin(token));
     }
 
+    @Operation(summary = "토큰 재발급", description = "Refresh Token을 통해 Access Token, Refresh Token을 재발급합니다.")
+    @Parameter(
+            name = "Authorization", description = "사용자의 Refresh Token", in = ParameterIn.HEADER,
+            required = true, example = "Bearer eyJ0eXAi..."
+    )
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(HttpServletRequest request) {
         return ResponseEntity.ok(oAuth2Service.refresh(request));


### PR DESCRIPTION
## 🔥 Related Issue
- Close #14 

## 🏃‍ Task
- Swagger-ui에 access-token(`Authorization` header) 관련 설정 추가
  - `Authorization` header의 값을 설정하고 싶다면 swagger-ui에서 **Authorize** 버튼을 누르면 나타나는 다음 화면에서 설정할 수 있다.
    <img width="758" alt="image" src="https://user-images.githubusercontent.com/60748900/221064360-7cefb790-0d46-4cb6-97de-95ccaf7c35b4.png">
  - Swagger-ui의 **Authorize** 기능과의 호환성, 로그인 권한이 필요한 API를 표시하기 위해서라도 access token이 필요한 API의 경우 `@Operation()`에 `security = @SecurityRequirement(name = "Authorization")` 속성을 **반드시** 추가해야 한다.


## 📄 Reference
- [Springdoc-openapi 공식문서](https://springdoc.org/)

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?