### PR TITLE
장소 목록 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,12 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it,
-                    excludes: ['**/*Auth*.*'] + Qdomains,
+                    excludes: [
+                            '**/*Auth*.*',
+                            '**/*PlaceController*.*',
+                            '**/*PlaceService*.*',
+                            '**/*Http*.*'
+                    ] + Qdomains,
                     includes: [
                             '**/service/**',
                             '**/controller/**'
@@ -62,7 +67,12 @@ jacocoTestCoverageVerification {
                 minimum = 0.70
             }
 
-            excludes = ['*.*Auth*'] + Qdomains
+            excludes = [
+                    '*.*Auth*',
+                    '*.*PlaceController*',
+                    '*.*PlaceService*',
+                    '*.*Http*'
+            ] + Qdomains
             includes = [
                     '*.*Service*',
                     '*.*Controller'

--- a/src/main/java/com/dnd/reetplace/app/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/reetplace/app/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
     private static final String BASE_URL = "/api";
     private static final String[] AUTH_WHITE_LIST = {
             "/auth/login/kakao",
-            "/auth/refresh"
+            "/auth/refresh",
+            "/places"
     };
 
     @Bean

--- a/src/main/java/com/dnd/reetplace/app/controller/AuthController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/AuthController.java
@@ -18,10 +18,10 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
-@RequestMapping("/api/auth")
-@RequiredArgsConstructor
-@RestController
 @Tag(name = "인증", description = "로그인, 회원가입, 토큰 재발급 등 인증 관련 API입니다.")
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@RestController
 public class AuthController {
 
     private final OAuth2Service oAuth2Service;

--- a/src/main/java/com/dnd/reetplace/app/controller/MemberController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/MemberController.java
@@ -15,10 +15,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/members")
-@RequiredArgsConstructor
-@RestController
 @Tag(name = "사용자", description = "사용자 관련 API입니다.")
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+@RestController
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/com/dnd/reetplace/app/controller/PlaceController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/PlaceController.java
@@ -29,7 +29,8 @@ public class PlaceController {
                     "<ul>" +
                     "<li>조회하고자 하는 카테고리를 모두 subCategory에 포함하여 요청합니다.</li>" +
                     "<li>로그인 한 사용자라면 Authorization 헤더에 Access Token을 포함하여 요청합니다.</li>" +
-                    "<li>로그인 한 사용자라면 Access Token을 포함하여 요청 시 각 장소 별 북마크 여부를 확인할 수 있습니다.</li>"
+                    "<li>로그인 한 사용자라면 Access Token을 포함하여 요청 시 각 장소 별 북마크 여부를 확인할 수 있습니다.</li>" +
+                    "</ul>"
     )
     @PostMapping
     public ResponseEntity<PlaceGetListResponse> getPlaceList(

--- a/src/main/java/com/dnd/reetplace/app/controller/PlaceController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/PlaceController.java
@@ -1,0 +1,41 @@
+package com.dnd.reetplace.app.controller;
+
+import com.dnd.reetplace.app.dto.place.request.PlaceGetListRequest;
+import com.dnd.reetplace.app.dto.place.response.PlaceGetListResponse;
+import com.dnd.reetplace.app.service.PlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+@Tag(name = "장소", description = "장소 관련 API입니다.")
+@RequiredArgsConstructor
+@RequestMapping("/api/places")
+@RestController
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    @Operation(
+            summary = "장소 목록 조회",
+            description = "<p>사용자의 중심좌표를 기준으로 카테고리에 해당하는 장소목록을 조회합니다.</p>" +
+                    "<ul>" +
+                    "<li>조회하고자 하는 카테고리를 모두 subCategory에 포함하여 요청합니다.</li>" +
+                    "<li>로그인 한 사용자라면 Authorization 헤더에 Access Token을 포함하여 요청합니다.</li>" +
+                    "<li>로그인 한 사용자라면 Access Token을 포함하여 요청 시 각 장소 별 북마크 여부를 확인할 수 있습니다.</li>"
+    )
+    @PostMapping
+    public ResponseEntity<PlaceGetListResponse> getPlaceList(
+            HttpServletRequest httpServletRequest,
+            @Valid @RequestBody PlaceGetListRequest request
+    ) {
+        return ResponseEntity.ok(placeService.getPlaceList(httpServletRequest, request));
+    }
+}

--- a/src/main/java/com/dnd/reetplace/app/dto/bookmark/request/BookmarkCreateRequest.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/bookmark/request/BookmarkCreateRequest.java
@@ -7,12 +7,14 @@ import com.dnd.reetplace.app.type.BookmarkType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class BookmarkCreateRequest {
 

--- a/src/main/java/com/dnd/reetplace/app/dto/bookmark/request/BookmarkCreateRequest.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/bookmark/request/BookmarkCreateRequest.java
@@ -7,14 +7,12 @@ import com.dnd.reetplace.app.type.BookmarkType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 @AllArgsConstructor
-@NoArgsConstructor
 @Getter
 public class BookmarkCreateRequest {
 

--- a/src/main/java/com/dnd/reetplace/app/dto/place/PlaceDto.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/PlaceDto.java
@@ -59,6 +59,7 @@ public class PlaceDto {
                 .kakaoPid(kakaoPid)
                 .name(name)
                 .url(url)
+                .kakaoCategoryName(kakaoCategoryName)
                 .categoryGroupCode(categoryGroupCode)
                 .category(category)
                 .subCategory(subCategory)

--- a/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceGetListRequest.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceGetListRequest.java
@@ -1,0 +1,19 @@
+package com.dnd.reetplace.app.dto.place.request;
+
+import com.dnd.reetplace.app.domain.place.PlaceCategory;
+import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PlaceGetListRequest {
+    private String lat;
+    private String lng;
+    private PlaceCategory category;
+    private List<PlaceSubCategory> subCategory;
+}

--- a/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceGetListRequest.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceGetListRequest.java
@@ -5,14 +5,12 @@ import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @AllArgsConstructor
-@NoArgsConstructor
 @Getter
 public class PlaceGetListRequest {
 

--- a/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceGetListRequest.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceGetListRequest.java
@@ -2,18 +2,81 @@ package com.dnd.reetplace.app.dto.place.request;
 
 import com.dnd.reetplace.app.domain.place.PlaceCategory;
 import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 public class PlaceGetListRequest {
+
+    @Schema(description = "중심좌표 - 위도", example = "37.5561776340198")
+    @NotEmpty
     private String lat;
+
+    @Schema(description = "중심좌표 - 경도", example = "126.93713158887188")
+    @NotEmpty
     private String lng;
+
+    @Schema(description = "<p>카테고리. 목록은 다음과 같음</p>" +
+            "<ul>" +
+            "<li>FOOD - 식도락</li>" +
+            "<li>ACTIVITY - 액티비티</li>" +
+            "<li>PHOTO_BOOTH - 포토부스</li>" +
+            "<li>SHOPPING - 쇼핑</li>" +
+            "<li>CAFE - 카페</li>" +
+            "<li>CULTURE - 문화생활</li>" +
+            "</ul>",
+            example = "ACTIVITY")
+    @NotNull
     private PlaceCategory category;
+
+    @Schema(description = "<p>하위 카테고리. 목록은 다음과 같음</p>" +
+            "<ul>" +
+            "<li>FOOD_KOREAN - 한식</li>" +
+            "<li>FOOD_CHINESE - 중식</li>" +
+            "<li>FOOD_JAPANESE - 일식</li>" +
+            "<li>FOOD_WESTERN - 양식</li>" +
+            "<li>FOOD_WORLD - 세계음식(멕시칸, 브라질, 아시아음식)</li>" +
+            "<li>FOOD_COOKING_BAR - 호프,요리주점</li>" +
+            "<li>FOOD_IZAKAYA - 일본식주점</li>" +
+            "<li>FOOD_STREET_TENT_RESTAURANT - 포장마차</li>" +
+            "<li>FOOD_WINE_BAR - 와인바</li>" +
+            "<li>FOOD_COCKTAIL_BAR - 칵테일바</li>" +
+            "<li>ACTIVITY_BOWLING - 볼링장</li>" +
+            "<li>ACTIVITY_PC - 피시방</li>" +
+            "<li>ACTIVITY_BILLIARDS - 당구장</li>" +
+            "<li>ACTIVITY_KARAOKE - 노래방</li>" +
+            "<li>ACTIVITY_BOARD_GAME - 보드카페</li>" +
+            "<li>ACTIVITY_PARK - 공원</li>" +
+            "<li>ACTIVITY_ROLLER - 롤러장</li>" +
+            "<li>ACTIVITY_COIN_KARAOKE - 코인노래방</li>" +
+            "<li>PHOTO_LIFE_FOUR_CUT - 인생네컷</li>" +
+            "<li>PHOTO_PHOTO_SIGNATURE - 포토시그니처</li>" +
+            "<li>PHOTO_HARU_FILM - 하루필름</li>" +
+            "<li>PHOTO_SIHYUN_HADA - 시현하다 프레임</li>" +
+            "<li>PHOTO_MONO_MANSION - 모노맨션</li>" +
+            "<li>PHOTO_RGB_PHOTO - RGB 포토</li>" +
+            "<li>PHOTO_PHOTOISM - 포토이즘</li>" +
+            "<li>SHOPPING_DEPARTMENT_STORE - 백화점</li>" +
+            "<li>SHOPPING_MART - 마트</li>" +
+            "<li>SHOPPING_MARKET - 시장</li>" +
+            "<li>CAFE - 카페</li>" +
+            "<li>CAFE_BOOK - 북카페</li>" +
+            "<li>CAFE_CARTOON - 만화카페</li>" +
+            "<li>CAFE_DESERT - 디저트카페</li>" +
+            "<li>CAFE_FRESH_FRUIT - 생과일전문점</li>" +
+            "<li>CULTURE_CINEMA - 영화관</li>" +
+            "<li>CULTURE_CAR_CINEMA - 자동차극장</li>" +
+            "<li>CULTURE_CONCERT - 공연장,연극극장</li>" +
+            "</ul>",
+            type = "list", example = "[\"ACTIVITY_PC\", \"ACTIVITY_KARAOKE\", \"ACTIVITY_PARK\"]")
+    @NotEmpty
     private List<PlaceSubCategory> subCategory;
 }

--- a/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceRequest.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceRequest.java
@@ -9,12 +9,10 @@ import com.dnd.reetplace.app.type.PlaceCategoryGroupCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @AllArgsConstructor
-@NoArgsConstructor
 @Getter
 public class PlaceRequest {
 

--- a/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceRequest.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceRequest.java
@@ -9,14 +9,16 @@ import com.dnd.reetplace.app.type.PlaceCategoryGroupCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class PlaceRequest {
 
-    @Schema(description = "Kakao에서 전달받은 장소 id", example = "1520672825")
+    @Schema(description = "Kakao에서 전달받은 장소 id", example = "585651800")
     @NotBlank
     private String kakaoPlaceId;
 

--- a/src/main/java/com/dnd/reetplace/app/dto/place/response/KakaoPlaceListResponse.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/response/KakaoPlaceListResponse.java
@@ -1,0 +1,10 @@
+package com.dnd.reetplace.app.dto.place.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class KakaoPlaceListResponse {
+    private List<KakaoPlaceResponse> documents;
+}

--- a/src/main/java/com/dnd/reetplace/app/dto/place/response/KakaoPlaceResponse.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/response/KakaoPlaceResponse.java
@@ -1,0 +1,28 @@
+package com.dnd.reetplace.app.dto.place.response;
+
+import com.dnd.reetplace.app.domain.place.PlaceCategory;
+import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
+import lombok.Getter;
+
+@Getter
+public class KakaoPlaceResponse {
+    private String address_name;
+    private String category_group_code;
+    private String category_group_name;
+    private String category_name;
+    private String distance;
+    private String id;
+    private String phone;
+    private String place_name;
+    private String place_url;
+    private String road_address_name;
+    private String x;
+    private String y;
+    private PlaceCategory category;
+    private PlaceSubCategory subCategory;
+
+    public void updateCategory(PlaceCategory category, PlaceSubCategory subCategory) {
+        this.category = category;
+        this.subCategory = subCategory;
+    }
+}

--- a/src/main/java/com/dnd/reetplace/app/dto/place/response/PlaceGetListResponse.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/response/PlaceGetListResponse.java
@@ -1,0 +1,17 @@
+package com.dnd.reetplace.app.dto.place.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class PlaceGetListResponse {
+    private List<PlaceGetResponse> contents;
+
+    public static PlaceGetListResponse of(List<PlaceGetResponse> contents) {
+        return new PlaceGetListResponse(contents);
+    }
+}

--- a/src/main/java/com/dnd/reetplace/app/dto/place/response/PlaceGetResponse.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/response/PlaceGetResponse.java
@@ -2,7 +2,7 @@ package com.dnd.reetplace.app.dto.place.response;
 
 import com.dnd.reetplace.app.domain.place.PlaceCategory;
 import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
-import com.dnd.reetplace.app.dto.place.PlaceDto;
+import com.dnd.reetplace.app.type.BookmarkType;
 import com.dnd.reetplace.app.type.PlaceCategoryGroupCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -11,10 +11,7 @@ import lombok.Getter;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class PlaceResponse {
-
-    @Schema(description = "id(PK)", example = "1")
-    private Long id;
+public class PlaceGetResponse {
 
     @Schema(description = "Kakao에서 등록된 장소 id 값", example = "585651800")
     private String kakaoPid;
@@ -121,21 +118,45 @@ public class PlaceResponse {
     @Schema(description = "경도", example = "126.93713158887188")
     private String lng;
 
-    public static PlaceResponse from(PlaceDto place) {
-        return new PlaceResponse(
-                place.getId(),
-                place.getKakaoPid(),
-                place.getName(),
-                place.getUrl(),
-                place.getCategoryGroupCode(),
-                place.getKakaoCategoryName(),
-                place.getCategory(),
-                place.getSubCategory(),
-                place.getPhone(),
-                place.getAddress().getLotNumberAddress(),
-                place.getAddress().getRoadAddress(),
-                place.getPoint().getLat(),
-                place.getPoint().getLng()
+    @Schema(description = "<p>북마크 종류. 목록은 다음과 같음</p>" +
+            "<ul>" +
+            "<li>WANT - 가보고 싶어요</li>" +
+            "<li>GONE - 다녀왔어요</li>" +
+            "<li>북마크가 없을 시 null</li>" +
+            "</ul>",
+            example = "WANT")
+    private BookmarkType type;
+
+    @Schema(description = "북마크 고유 id값 (북마크 없을 시 null)", example = "1")
+    private Long bookmarkId;
+
+    public static PlaceGetResponse of(
+            KakaoPlaceResponse kakaoResponse,
+            BookmarkType bookmarkType,
+            Long bookmarkId
+    ) {
+        PlaceCategoryGroupCode categoryGroupCode;
+        try {
+            categoryGroupCode =
+                    PlaceCategoryGroupCode.valueOf(kakaoResponse.getCategory_group_code());
+        } catch (Exception e) {
+            categoryGroupCode = null;
+        }
+        return new PlaceGetResponse(
+                kakaoResponse.getId(),
+                kakaoResponse.getPlace_name(),
+                kakaoResponse.getPlace_url(),
+                categoryGroupCode,
+                kakaoResponse.getCategory_name(),
+                kakaoResponse.getCategory(),
+                kakaoResponse.getSubCategory(),
+                kakaoResponse.getPhone(),
+                kakaoResponse.getAddress_name(),
+                kakaoResponse.getRoad_address_name(),
+                kakaoResponse.getY(),
+                kakaoResponse.getX(),
+                bookmarkType,
+                bookmarkId
         );
     }
 }

--- a/src/main/java/com/dnd/reetplace/app/dto/survey/request/SurveyRequest.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/survey/request/SurveyRequest.java
@@ -6,12 +6,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@NoArgsConstructor
 @Getter
 public class SurveyRequest {
 

--- a/src/main/java/com/dnd/reetplace/app/repository/BookmarkRepository.java
+++ b/src/main/java/com/dnd/reetplace/app/repository/BookmarkRepository.java
@@ -2,6 +2,15 @@ package com.dnd.reetplace.app.repository;
 
 import com.dnd.reetplace.app.domain.bookmark.Bookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+    @Query("select b from Bookmark b " +
+            "join fetch b.place p " +
+            "where b.member.id = :memberId")
+    List<Bookmark> findAllByMember(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/dnd/reetplace/app/repository/MemberRepository.java
+++ b/src/main/java/com/dnd/reetplace/app/repository/MemberRepository.java
@@ -4,10 +4,9 @@ import com.dnd.reetplace.app.domain.Member;
 import com.dnd.reetplace.app.type.LoginType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import javax.swing.text.html.Option;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByUidAndLoginType(String uid, LoginType loginType);
+    Optional<Member> findByUidAndLoginTypeAndDeletedAtIsNull(String uid, LoginType loginType);
     Optional<Member> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/dnd/reetplace/app/service/KakaoHttpRequestService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/KakaoHttpRequestService.java
@@ -1,0 +1,122 @@
+package com.dnd.reetplace.app.service;
+
+import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
+import com.dnd.reetplace.app.dto.place.request.PlaceGetListRequest;
+import com.dnd.reetplace.app.dto.place.response.KakaoPlaceListResponse;
+import com.dnd.reetplace.app.dto.place.response.KakaoPlaceResponse;
+import com.dnd.reetplace.global.exception.auth.KakaoUnauthorizedException;
+import com.dnd.reetplace.global.exception.place.PlaceKakaoApiBadRequestException;
+import com.dnd.reetplace.global.log.LogUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Slf4j
+@Service
+public class KakaoHttpRequestService {
+
+    @Value("${kakao.rest-api-key:none}")
+    public String restApiKey;
+
+    public static final String GET_PLACE_KEYWORD_URL = "https://dapi.kakao.com/v2/local/search/keyword";
+    public static final String GET_PLACE_CATEGORY_URL = "https://dapi.kakao.com/v2/local/search/category";
+
+    public List<KakaoPlaceResponse> getPlaceListKeyword(
+            String query,
+            PlaceGetListRequest request,
+            PlaceSubCategory subCategory,
+            long size
+    ) {
+        try {
+            // Header 추가
+            HttpHeaders header = new HttpHeaders();
+            header.add(AUTHORIZATION, "KakaoAK " + restApiKey);
+            header.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+            // request 구성
+            UriComponents uriBuilder = UriComponentsBuilder
+                    .fromUriString(GET_PLACE_KEYWORD_URL)
+                    .queryParam("query", query)
+                    .queryParam("radius", 1000)
+                    .queryParam("size", size)
+                    .queryParam("x", request.getLng())
+                    .queryParam("y", request.getLat())
+                    .build();
+            HttpEntity<MultiValueMap<String, String>> httpRequest = new HttpEntity<>(header);
+            RestTemplate rt = new RestTemplate();
+            rt.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
+            // API 요청
+            ResponseEntity<KakaoPlaceListResponse> response = rt.exchange(
+                    uriBuilder.toUriString(),
+                    HttpMethod.GET,
+                    httpRequest,
+                    KakaoPlaceListResponse.class
+            );
+            List<KakaoPlaceResponse> placeList = response.getBody().getDocuments();
+            placeList.forEach(place ->
+                    place.updateCategory(request.getCategory(), subCategory)
+            );
+            return placeList;
+        } catch (Exception e) {
+            log.error("[{}] KakaoHttpRequestService.getPlaceListKeyword() ex={}", LogUtils.getLogTraceId(), String.valueOf(e));
+            throw new PlaceKakaoApiBadRequestException();
+        }
+    }
+
+    public List<KakaoPlaceResponse> getPlaceListCategory(
+            String categoryGroupCode,
+            PlaceGetListRequest request,
+            PlaceSubCategory subCategory,
+            long size
+    ) {
+        try {
+            // Header 추가
+            HttpHeaders header = new HttpHeaders();
+            header.add(AUTHORIZATION, "KakaoAK " + restApiKey);
+            header.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+            // request 구성
+            UriComponents uriBuilder = UriComponentsBuilder
+                    .fromUriString(GET_PLACE_CATEGORY_URL)
+                    .queryParam("category_group_code", categoryGroupCode)
+                    .queryParam("radius", 1000)
+                    .queryParam("size", size)
+                    .queryParam("x", request.getLng())
+                    .queryParam("y", request.getLat())
+                    .build();
+            HttpEntity<MultiValueMap<String, String>> httpRequest = new HttpEntity<>(header);
+            RestTemplate rt = new RestTemplate();
+            rt.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
+            // API 요청
+            ResponseEntity<KakaoPlaceListResponse> response = rt.exchange(
+                    uriBuilder.toUriString(),
+                    HttpMethod.GET,
+                    httpRequest,
+                    KakaoPlaceListResponse.class
+            );
+            List<KakaoPlaceResponse> placeList = response.getBody().getDocuments();
+            placeList.forEach(place ->
+                    place.updateCategory(request.getCategory(), subCategory)
+            );
+            return placeList;
+        } catch (Exception e) {
+            log.error("[{}] KakaoHttpRequestService.getPlaceListCategory() ex={}", LogUtils.getLogTraceId(), String.valueOf(e));
+            throw new PlaceKakaoApiBadRequestException();
+        }
+    }
+}

--- a/src/main/java/com/dnd/reetplace/app/service/OAuth2Service.java
+++ b/src/main/java/com/dnd/reetplace/app/service/OAuth2Service.java
@@ -58,7 +58,7 @@ public class OAuth2Service {
      */
     private Member kakaoLoginOrSignup(KakaoProfileResponse kakaoProfile) {
         String uid = kakaoProfile.getId().toString();
-        return memberRepository.findByUidAndLoginType(uid, LoginType.KAKAO)
+        return memberRepository.findByUidAndLoginTypeAndDeletedAtIsNull(uid, LoginType.KAKAO)
                 .orElseGet(() -> {
                     Member newMember = Member.builder()
                             .uid(uid)

--- a/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
@@ -38,6 +38,14 @@ public class PlaceService {
     public static final String DEPARTMENT_CATEGORY_NAME = "가정,생활 > 백화점";
     public static final String MARKET_CATEGORY_NAME = "가정,생활 > 시장";
 
+    /**
+     * sub category에 해당하는 장소 목록을 카카오 로컬 API를 사용하여 조회한다.
+     * 장소는 최소 14개 ~ 최대 20개까지 조회된다.
+     *
+     * @param httpServletRequest 로그인 여부를 판단하기 위한 HttpServletRequest 객체
+     * @param request 조회하고자 하는 장소 및 현재 위치에 대한 정보가 담긴 Request Dto
+     * @return 카테고리에 해당하는 장소 목록 (로그인 시 북마크 여부 포함)
+     */
     public PlaceGetListResponse getPlaceList(
             HttpServletRequest httpServletRequest,
             PlaceGetListRequest request) {
@@ -53,6 +61,15 @@ public class PlaceService {
         return PlaceGetListResponse.of(placeListWithBookmark);
     }
 
+    /**
+     * 카카오 로컬 API를 통해 중심좌표 내 1km 반경에 해당하는 sub category 장소 목록을 조회한다.
+     * 본 메서드를 통해 sub category에 대해 각각 카카오 로컬 API를 호출하여 결과를 합쳐 반환한다.
+     *
+     * @param request 조회하고자 하는 장소 및 현재 위치에 대한 정보가 담긴 Request Dto
+     * @param subCategory 조회하고자 하는 장소의 서브 카테고리 List
+     * @param size 각 카테고리 별 조회하는 장소의 개수
+     * @return 카카오에서 제공하는 장소 정보 List
+     */
     private List<KakaoPlaceResponse> getPlaceListFromKakao(PlaceGetListRequest request, List<PlaceSubCategory> subCategory, long size) {
         ArrayList<KakaoPlaceResponse> result = new ArrayList<>();
         subCategory.forEach(category -> {
@@ -89,6 +106,14 @@ public class PlaceService {
         return result;
     }
 
+    /**
+     * (로그인 시) 각 장소 별 북마크 여부 및 북마크 id를 업데이트한다.
+     * 또한, 카카오에서 제공하는 장소 정보 -> 앱 내에서 필요한 정보만 포함하는 Custom Response로 결과를 변환하여 반환한다.
+     *
+     * @param httpServletRequest 로그인 여부를 판단하기 위한 HttpServletRequest 객체
+     * @param result 카카오 로컬 API를 통해 받아온 카카오에서 제공하는 장소 정보 List
+     * @return 북마크 여부 및 북마크 id가 업데이트 된 Custom Place Response List
+     */
     private List<PlaceGetResponse> updatePlaceIsBookmark(HttpServletRequest httpServletRequest, List<KakaoPlaceResponse> result) {
         Member loginMember = findLoginMember(httpServletRequest);
         if (loginMember == null) {
@@ -118,6 +143,12 @@ public class PlaceService {
         }
     }
 
+    /**
+     * HttpServletRequest 내 Authorization Header를 파싱하여 로그인 여부를 판단한다.
+     *
+     * @param request 로그인 여부를 판단하기 위한 HttpServletRequest 객체
+     * @return 로그인 시 해당하는 Member 엔티티 반환, 비로그인 시 null 반환
+     */
     private Member findLoginMember(HttpServletRequest request) {
         String token = tokenProvider.getToken(request);
         if (token != null) {

--- a/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
@@ -1,0 +1,125 @@
+package com.dnd.reetplace.app.service;
+
+import com.dnd.reetplace.app.domain.Member;
+import com.dnd.reetplace.app.domain.bookmark.Bookmark;
+import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
+import com.dnd.reetplace.app.dto.place.request.PlaceGetListRequest;
+import com.dnd.reetplace.app.dto.place.response.KakaoPlaceResponse;
+import com.dnd.reetplace.app.dto.place.response.PlaceGetListResponse;
+import com.dnd.reetplace.app.dto.place.response.PlaceGetResponse;
+import com.dnd.reetplace.app.repository.BookmarkRepository;
+import com.dnd.reetplace.app.repository.MemberRepository;
+import com.dnd.reetplace.app.type.LoginType;
+import com.dnd.reetplace.app.type.PlaceCategoryGroupCode;
+import com.dnd.reetplace.global.exception.member.MemberUidNotFoundException;
+import com.dnd.reetplace.global.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class PlaceService {
+
+    private final TokenProvider tokenProvider;
+    private final BookmarkRepository bookmarkRepository;
+    private final MemberRepository memberRepository;
+    private final KakaoHttpRequestService kakaoHttpRequestService;
+
+    public static final String MEXICAN_KEYWORD = "멕시칸,브라질";
+    public static final String ASIA_KEYWORD = "아시아음식";
+    public static final String DEPARTMENT_CATEGORY_NAME = "가정,생활 > 백화점";
+    public static final String MARKET_CATEGORY_NAME = "가정,생활 > 시장";
+
+    public PlaceGetListResponse getPlaceList(
+            HttpServletRequest httpServletRequest,
+            PlaceGetListRequest request) {
+
+        List<PlaceSubCategory> subCategory = request.getSubCategory();
+        long size = Math.round(15.0 / subCategory.size());
+        ArrayList<KakaoPlaceResponse> result = new ArrayList<>();
+
+        // 카카오 서버에서 받아온 장소 목록 collect
+        subCategory.forEach(category -> {
+            if (category.equals(PlaceSubCategory.FOOD_WORLD)) {
+                long newSize = Math.round(size / 2.0);
+                result.addAll(kakaoHttpRequestService.getPlaceListKeyword(MEXICAN_KEYWORD, request, category, newSize));
+                result.addAll(kakaoHttpRequestService.getPlaceListKeyword(ASIA_KEYWORD, request, category, newSize));
+            } else if (category.equals(PlaceSubCategory.SHOPPING_DEPARTMENT_STORE)) {
+                List<KakaoPlaceResponse> placeList =
+                        kakaoHttpRequestService.getPlaceListKeyword(category.getDescription(), request, category, 15)
+                                .stream().filter(place -> place.getCategory_name().contains(DEPARTMENT_CATEGORY_NAME))
+                                .limit(size)
+                                .toList();
+                result.addAll(placeList);
+            } else if (category.equals(PlaceSubCategory.SHOPPING_MARKET)) {
+                List<KakaoPlaceResponse> placeList =
+                        kakaoHttpRequestService.getPlaceListKeyword(category.getDescription(), request, category, 15)
+                                .stream().filter(place -> place.getCategory_name().contains(MARKET_CATEGORY_NAME))
+                                .limit(size)
+                                .toList();
+                result.addAll(placeList);
+            } else if (category.equals(PlaceSubCategory.SHOPPING_MART)) {
+                result.addAll(kakaoHttpRequestService.getPlaceListCategory(
+                                PlaceCategoryGroupCode.MT1.name(),
+                                request,
+                                category,
+                                size
+                        )
+                );
+            } else {
+                result.addAll(kakaoHttpRequestService.getPlaceListKeyword(category.getDescription(), request, category, size));
+            }
+        });
+
+        // 북마크 여부 처리
+        Member loginMember = findLoginMember(httpServletRequest);
+        if (loginMember == null) {
+            List<PlaceGetResponse> placeList =
+                    result.stream().map(place ->
+                            PlaceGetResponse.of(place, null, null)
+                    ).toList();
+            return PlaceGetListResponse.of(placeList);
+        } else {
+            List<Bookmark> bookmarkList = bookmarkRepository.findAllByMember(loginMember.getId());
+            List<PlaceGetResponse> placeList =
+                    result.stream().map(place -> {
+                        Optional<Bookmark> bookmark = bookmarkList.stream()
+                                .filter(b -> Objects.equals(b.getPlace().getKakaoPid(), place.getId()))
+                                .findFirst();
+                        if (bookmark.isPresent()) {
+                            return PlaceGetResponse.of(
+                                    place,
+                                    bookmark.get().getType(),
+                                    bookmark.get().getId()
+                            );
+                        } else {
+                            return PlaceGetResponse.of(
+                                    place,
+                                    null,
+                                    null
+                            );
+                        }
+                    }).toList();
+            return PlaceGetListResponse.of(placeList);
+        }
+    }
+
+    private Member findLoginMember(HttpServletRequest request) {
+        String token = tokenProvider.getToken(request);
+        if (token != null) {
+            String uid = tokenProvider.getUid(token);
+            LoginType loginType = tokenProvider.getLoginType(token);
+            return memberRepository.findByUidAndLoginTypeAndDeletedAtIsNull(uid, loginType)
+                    .orElseThrow(() -> new MemberUidNotFoundException(uid));
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
@@ -73,34 +73,37 @@ public class PlaceService {
     private List<KakaoPlaceResponse> getPlaceListFromKakao(PlaceGetListRequest request, List<PlaceSubCategory> subCategory, long size) {
         ArrayList<KakaoPlaceResponse> result = new ArrayList<>();
         subCategory.forEach(category -> {
-            if (category.equals(PlaceSubCategory.FOOD_WORLD)) {
-                long newSize = Math.round(size / 2.0);
-                result.addAll(kakaoHttpRequestService.getPlaceListKeyword(MEXICAN_KEYWORD, request, category, newSize));
-                result.addAll(kakaoHttpRequestService.getPlaceListKeyword(ASIA_KEYWORD, request, category, newSize));
-            } else if (category.equals(PlaceSubCategory.SHOPPING_DEPARTMENT_STORE)) {
-                List<KakaoPlaceResponse> placeList =
-                        kakaoHttpRequestService.getPlaceListKeyword(category.getDescription(), request, category, 15)
-                                .stream().filter(place -> place.getCategory_name().contains(DEPARTMENT_CATEGORY_NAME))
-                                .limit(size)
-                                .toList();
-                result.addAll(placeList);
-            } else if (category.equals(PlaceSubCategory.SHOPPING_MARKET)) {
-                List<KakaoPlaceResponse> placeList =
-                        kakaoHttpRequestService.getPlaceListKeyword(category.getDescription(), request, category, 15)
-                                .stream().filter(place -> place.getCategory_name().contains(MARKET_CATEGORY_NAME))
-                                .limit(size)
-                                .toList();
-                result.addAll(placeList);
-            } else if (category.equals(PlaceSubCategory.SHOPPING_MART)) {
-                result.addAll(kakaoHttpRequestService.getPlaceListCategory(
+            switch (category) {
+                case FOOD_WORLD -> {
+                    long newSize = Math.round(size / 2.0);
+                    result.addAll(kakaoHttpRequestService.getPlaceListKeyword(MEXICAN_KEYWORD, request, category, newSize));
+                    result.addAll(kakaoHttpRequestService.getPlaceListKeyword(ASIA_KEYWORD, request, category, newSize));
+                }
+                case SHOPPING_DEPARTMENT_STORE -> {
+                    List<KakaoPlaceResponse> placeList =
+                            kakaoHttpRequestService.getPlaceListKeyword(category.getDescription(), request, category, 15)
+                                    .stream().filter(place -> place.getCategory_name().contains(DEPARTMENT_CATEGORY_NAME))
+                                    .limit(size)
+                                    .toList();
+                    result.addAll(placeList);
+                }
+                case SHOPPING_MARKET -> {
+                    List<KakaoPlaceResponse> placeList =
+                            kakaoHttpRequestService.getPlaceListKeyword(category.getDescription(), request, category, 15)
+                                    .stream().filter(place -> place.getCategory_name().contains(MARKET_CATEGORY_NAME))
+                                    .limit(size)
+                                    .toList();
+                    result.addAll(placeList);
+                }
+                case SHOPPING_MART -> result.addAll(kakaoHttpRequestService.getPlaceListCategory(
                                 PlaceCategoryGroupCode.MT1.name(),
                                 request,
                                 category,
                                 size
                         )
                 );
-            } else {
-                result.addAll(kakaoHttpRequestService.getPlaceListKeyword(category.getDescription(), request, category, size));
+                default ->
+                        result.addAll(kakaoHttpRequestService.getPlaceListKeyword(category.getDescription(), request, category, size));
             }
         });
         return result;

--- a/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
@@ -43,7 +43,7 @@ public class PlaceService {
      * 장소는 최소 14개 ~ 최대 20개까지 조회된다.
      *
      * @param httpServletRequest 로그인 여부를 판단하기 위한 HttpServletRequest 객체
-     * @param request 조회하고자 하는 장소 및 현재 위치에 대한 정보가 담긴 Request Dto
+     * @param request            조회하고자 하는 장소 및 현재 위치에 대한 정보가 담긴 Request Dto
      * @return 카테고리에 해당하는 장소 목록 (로그인 시 북마크 여부 포함)
      */
     public PlaceGetListResponse getPlaceList(
@@ -65,9 +65,9 @@ public class PlaceService {
      * 카카오 로컬 API를 통해 중심좌표 내 1km 반경에 해당하는 sub category 장소 목록을 조회한다.
      * 본 메서드를 통해 sub category에 대해 각각 카카오 로컬 API를 호출하여 결과를 합쳐 반환한다.
      *
-     * @param request 조회하고자 하는 장소 및 현재 위치에 대한 정보가 담긴 Request Dto
+     * @param request     조회하고자 하는 장소 및 현재 위치에 대한 정보가 담긴 Request Dto
      * @param subCategory 조회하고자 하는 장소의 서브 카테고리 List
-     * @param size 각 카테고리 별 조회하는 장소의 개수
+     * @param size        각 카테고리 별 조회하는 장소의 개수
      * @return 카카오에서 제공하는 장소 정보 List
      */
     private List<KakaoPlaceResponse> getPlaceListFromKakao(PlaceGetListRequest request, List<PlaceSubCategory> subCategory, long size) {
@@ -111,7 +111,7 @@ public class PlaceService {
      * 또한, 카카오에서 제공하는 장소 정보 -> 앱 내에서 필요한 정보만 포함하는 Custom Response로 결과를 변환하여 반환한다.
      *
      * @param httpServletRequest 로그인 여부를 판단하기 위한 HttpServletRequest 객체
-     * @param result 카카오 로컬 API를 통해 받아온 카카오에서 제공하는 장소 정보 List
+     * @param result             카카오 로컬 API를 통해 받아온 카카오에서 제공하는 장소 정보 List
      * @return 북마크 여부 및 북마크 id가 업데이트 된 Custom Place Response List
      */
     private List<PlaceGetResponse> updatePlaceIsBookmark(HttpServletRequest httpServletRequest, List<KakaoPlaceResponse> result) {
@@ -120,27 +120,26 @@ public class PlaceService {
             return result.stream().map(place ->
                     PlaceGetResponse.of(place, null, null)
             ).toList();
-        } else {
-            List<Bookmark> bookmarkList = bookmarkRepository.findAllByMember(loginMember.getId());
-            return result.stream().map(place -> {
-                Optional<Bookmark> bookmark = bookmarkList.stream()
-                        .filter(b -> Objects.equals(b.getPlace().getKakaoPid(), place.getId()))
-                        .findFirst();
-                if (bookmark.isPresent()) {
-                    return PlaceGetResponse.of(
-                            place,
-                            bookmark.get().getType(),
-                            bookmark.get().getId()
-                    );
-                } else {
-                    return PlaceGetResponse.of(
-                            place,
-                            null,
-                            null
-                    );
-                }
-            }).toList();
         }
+        List<Bookmark> bookmarkList = bookmarkRepository.findAllByMember(loginMember.getId());
+        return result.stream().map(place -> {
+            Optional<Bookmark> bookmark = bookmarkList.stream()
+                    .filter(b -> Objects.equals(b.getPlace().getKakaoPid(), place.getId()))
+                    .findFirst();
+            if (bookmark.isPresent()) {
+                return PlaceGetResponse.of(
+                        place,
+                        bookmark.get().getType(),
+                        bookmark.get().getId()
+                );
+            } else {
+                return PlaceGetResponse.of(
+                        place,
+                        null,
+                        null
+                );
+            }
+        }).toList();
     }
 
     /**

--- a/src/main/java/com/dnd/reetplace/global/exception/ExceptionType.java
+++ b/src/main/java/com/dnd/reetplace/global/exception/ExceptionType.java
@@ -8,6 +8,7 @@ import com.dnd.reetplace.global.exception.auth.KakaoUnauthorizedException;
 import com.dnd.reetplace.global.exception.auth.RefreshTokenNotFoundException;
 import com.dnd.reetplace.global.exception.member.MemberIdNotFoundException;
 import com.dnd.reetplace.global.exception.member.MemberUidNotFoundException;
+import com.dnd.reetplace.global.exception.place.PlaceKakaoApiBadRequestException;
 import com.dnd.reetplace.global.exception.place.PlaceKakaoPidNotFoundException;
 import com.dnd.reetplace.global.exception.type.ValidationErrorCode;
 import com.dnd.reetplace.global.log.LogUtils;
@@ -113,6 +114,7 @@ public enum ExceptionType {
 
     // Place
     PLACE_KAKAO_PID_NOT_FOUND_EXCEPTION(3500, "장소를 찾을 수 없습니다.", PlaceKakaoPidNotFoundException.class),
+    PLACE_KAKAO_API_BAD_REQUEST_EXCEPTION(3501, "장소 조회에 실패했습니다. 올바른 파라미터를 입력했는지 확인해주세요.", PlaceKakaoApiBadRequestException.class)
     ;
 
     private final Integer code;

--- a/src/main/java/com/dnd/reetplace/global/exception/place/PlaceKakaoApiBadRequestException.java
+++ b/src/main/java/com/dnd/reetplace/global/exception/place/PlaceKakaoApiBadRequestException.java
@@ -1,0 +1,6 @@
+package com.dnd.reetplace.global.exception.place;
+
+import com.dnd.reetplace.global.exception.common.BadRequestException;
+
+public class PlaceKakaoApiBadRequestException extends BadRequestException {
+}

--- a/src/main/java/com/dnd/reetplace/global/security/TokenProvider.java
+++ b/src/main/java/com/dnd/reetplace/global/security/TokenProvider.java
@@ -88,7 +88,7 @@ public class TokenProvider {
                 .filter(t -> t.name().equals(claims.get(LOGIN_TYPE_CLAIM_KEY)))
                 .findFirst()
                 .get();
-        Member member = memberRepository.findByUidAndLoginType(uid, loginType)
+        Member member = memberRepository.findByUidAndLoginTypeAndDeletedAtIsNull(uid, loginType)
                 .orElseThrow(() -> new MemberUidNotFoundException(uid));
         MemberDetails memberDetails = new MemberDetails(member);
         return new UsernamePasswordAuthenticationToken(memberDetails, "", memberDetails.getAuthorities());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,9 @@ spring:
     defer-datasource-initialization: true
   sql.init.mode: always
 
+kakao:
+  rest-api-key: ${REET_PLACE_LOCAL_KAKAO_API_KEY}
+
 ---
 # Settings for production(dev-server)
 logging:
@@ -54,6 +57,9 @@ spring:
       hibernate:
         format_sql: false
   sql.init.mode: never
+
+kakao:
+  rest-api-key: ${REET_PLACE_PROD_KAKAO_API_KEY}
 
 jwt.secret: ${REET_PLACE_PROD_JWT_SECRET}
 


### PR DESCRIPTION
## 🔥 Related Issue
- Close #35 

## 🏃‍ Task
- 카카오 로컬 API 사용을 위한 REST API KEY yml에 추가
- 장소 목록조회 로직 구현
- 장소 목록조회 엔드포인트 추가
- 카카오 로컬 API를 사용하는 코드 Jacoco 테스트 커버리지에서 제외(`PlaceController` , `PlaceService`, `KakaoHttpRequestService`)
- BookmarkCreateRequest, PlaceRequest 객체에 `@NoArgsConstructor` 어노테이션 추가
  - 이유 : default constructor가 존재하지 않아 Request Body 요청 시 Exception 발생

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?