### PR TITLE
북마크 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/dnd/reetplace/app/controller/BookmarkController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/BookmarkController.java
@@ -4,6 +4,7 @@ import com.dnd.reetplace.app.dto.bookmark.BookmarkDto;
 import com.dnd.reetplace.app.dto.bookmark.request.BookmarkCreateRequest;
 import com.dnd.reetplace.app.dto.bookmark.response.BookmarkResponse;
 import com.dnd.reetplace.app.service.BookmarkService;
+import com.dnd.reetplace.app.type.BookmarkSearchSort;
 import com.dnd.reetplace.app.type.BookmarkSearchType;
 import com.dnd.reetplace.global.security.MemberDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,13 +51,13 @@ public class BookmarkController {
             description = "북마크 내역을 불러옵니다. 한 페이지에 20개의 데이터가 응답됩니다.",
             security = @SecurityRequirement(name = "Authorization")
     )
-    @GetMapping("/list")
+    @GetMapping
     public ResponseEntity<Slice<BookmarkResponse>> searchBookmarks(
             @Parameter(hidden = true) @AuthenticationPrincipal MemberDetails memberDetails,
             @Parameter(
                     description = "<p>북마크 검색 종류. 목록은 다음과 같음</p>" +
                             "<ul>" +
-                            "<li>ALL - 전체 조회" +
+                            "<li>ALL - 전체 조회</li>" +
                             "<li>WANT - 가보고 싶어요</li>" +
                             "<li>GONE - 다녀왔어요</li>" +
                             "</ul>",
@@ -69,11 +70,21 @@ public class BookmarkController {
             @Parameter(
                     description = "한 페이지에 담긴 데이터의 최대 개수(사이즈). 기본값은 20입니다.",
                     example = "20"
-            ) @RequestParam(required = false, defaultValue = "20") int size
+            ) @RequestParam(required = false, defaultValue = "20") int size,
+            @Parameter(
+                    description = "<p>북마크 검색 정렬 기준. 목록은 다음과 같음</p>" +
+                            "<ul>" +
+                            "<li>LATEST - 최신순</li>" +
+                            "<li>POPULARITY - 인기순</li>" +
+                            "</ul>",
+                    example = "ALL"
+            )
+            @RequestParam(required = false, defaultValue = "LATEST") BookmarkSearchSort sort
     ) {
         Slice<BookmarkResponse> response = bookmarkService.searchBookmarks(
                 memberDetails.getId(),
                 searchType,
+                sort,
                 PageRequest.of(page, size)
         ).map(BookmarkResponse::from);
 

--- a/src/main/java/com/dnd/reetplace/app/controller/BookmarkController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/BookmarkController.java
@@ -73,6 +73,7 @@ public class BookmarkController {
             ) @RequestParam(required = false, defaultValue = "20") int size,
             @Parameter(
                     description = "<p>북마크 검색 정렬 기준. 목록은 다음과 같음</p>" +
+                            "<p>현재 인기순 정렬은 구현이 되지 않은 상태. 최신순 정렬로만 검색 가능</p>" +
                             "<ul>" +
                             "<li>LATEST - 최신순</li>" +
                             "<li>POPULARITY - 인기순</li>" +

--- a/src/main/java/com/dnd/reetplace/app/dto/bookmark/response/BookmarkResponse.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/bookmark/response/BookmarkResponse.java
@@ -1,6 +1,5 @@
 package com.dnd.reetplace.app.dto.bookmark.response;
 
-import com.dnd.reetplace.app.domain.bookmark.BookMarkRelLink;
 import com.dnd.reetplace.app.dto.bookmark.BookmarkDto;
 import com.dnd.reetplace.app.dto.member.response.MemberResponse;
 import com.dnd.reetplace.app.dto.place.response.PlaceResponse;
@@ -12,7 +11,7 @@ import lombok.Getter;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class BookmarkCreateResponse {
+public class BookmarkResponse {
 
     @Schema(description = "생성된 북마크 PK", example = "1")
     private Long id;
@@ -46,8 +45,8 @@ public class BookmarkCreateResponse {
     @Schema(description = "장소와 관련된 URL3", example = "null")
     private String relLink3;
 
-    public static BookmarkCreateResponse from(BookmarkDto bookmarkDto) {
-        return new BookmarkCreateResponse(
+    public static BookmarkResponse from(BookmarkDto bookmarkDto) {
+        return new BookmarkResponse(
                 bookmarkDto.getId(),
                 MemberResponse.from(bookmarkDto.getMember()),
                 PlaceResponse.from(bookmarkDto.getPlace()),

--- a/src/main/java/com/dnd/reetplace/app/repository/BookmarkRepository.java
+++ b/src/main/java/com/dnd/reetplace/app/repository/BookmarkRepository.java
@@ -1,6 +1,10 @@
 package com.dnd.reetplace.app.repository;
 
 import com.dnd.reetplace.app.domain.bookmark.Bookmark;
+import com.dnd.reetplace.app.type.BookmarkType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +17,10 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
             "join fetch b.place p " +
             "where b.member.id = :memberId")
     List<Bookmark> findAllByMember(@Param("memberId") Long memberId);
+
+    @EntityGraph(attributePaths = {"member", "place"})
+    Slice<Bookmark> findByMember_Id(Long memberId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member", "place"})
+    Slice<Bookmark> findByTypeAndMember_Id(BookmarkType type, Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/dnd/reetplace/app/repository/BookmarkRepository.java
+++ b/src/main/java/com/dnd/reetplace/app/repository/BookmarkRepository.java
@@ -19,8 +19,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     List<Bookmark> findAllByMember(@Param("memberId") Long memberId);
 
     @EntityGraph(attributePaths = {"member", "place"})
-    Slice<Bookmark> findByMember_Id(Long memberId, Pageable pageable);
+    Slice<Bookmark> findByMember_IdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"member", "place"})
-    Slice<Bookmark> findByTypeAndMember_Id(BookmarkType type, Long memberId, Pageable pageable);
+    Slice<Bookmark> findByTypeAndMember_IdOrderByCreatedAtDesc(BookmarkType type, Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/dnd/reetplace/app/service/BookmarkService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/BookmarkService.java
@@ -7,6 +7,7 @@ import com.dnd.reetplace.app.dto.place.PlaceDto;
 import com.dnd.reetplace.app.repository.BookmarkRepository;
 import com.dnd.reetplace.app.repository.MemberRepository;
 import com.dnd.reetplace.app.repository.PlaceRepository;
+import com.dnd.reetplace.app.type.BookmarkSearchSort;
 import com.dnd.reetplace.app.type.BookmarkSearchType;
 import com.dnd.reetplace.global.exception.member.MemberIdNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.dnd.reetplace.app.type.BookmarkSearchType.ALL;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -27,7 +30,7 @@ public class BookmarkService {
     /**
      * 특정 장소에 대한 북마크를 생성한다.
      *
-     * @param memberId 북마크를 하고자 하는 회원의 PK
+     * @param memberId    북마크를 하고자 하는 회원의 PK
      * @param bookmarkDto 북마크 생성을 위해 필요한 정보. 장소에 대한 정보도 포함되어 있음
      * @return 생성된 북마크 정보
      */
@@ -47,19 +50,22 @@ public class BookmarkService {
     /**
      * 북마크 리스트를 검색한다.
      *
-     * @param memberId 북마크 리스트를 검색하고자 하는 로그인 회원
+     * @param memberId   북마크 리스트를 검색하고자 하는 로그인 회원
      * @param searchType 검색하고자 하는 북마크 리스트의 종류 (전체, 가고 싶어요, 갔다 왔어요)
-     * @param pageable paging 정보
+     * @param sort       정렬 기준 (최신순, 인기순)
+     * @param pageable   paging 정보
      * @return 북마크 정보가 담긴 {@link Slice} 객체
      */
-    public Slice<BookmarkDto> searchBookmarks(Long memberId, BookmarkSearchType searchType, Pageable pageable) {
-        if (searchType.equals(BookmarkSearchType.ALL)) {
-            return bookmarkRepository.findByMember_Id(memberId, pageable)
+    public Slice<BookmarkDto> searchBookmarks(Long memberId, BookmarkSearchType searchType, BookmarkSearchSort sort, Pageable pageable) {
+        if (searchType.equals(ALL)) {
+            return bookmarkRepository
+                    .findByMember_IdOrderByCreatedAtDesc(memberId, pageable)
+                    .map(BookmarkDto::from);
+        } else {
+            return bookmarkRepository
+                    .findByTypeAndMember_IdOrderByCreatedAtDesc(searchType.toBookmarkType(), memberId, pageable)
                     .map(BookmarkDto::from);
         }
-
-        return bookmarkRepository.findByTypeAndMember_Id(searchType.toBookmarkType(), memberId, pageable)
-                .map(BookmarkDto::from);
     }
 
     /**

--- a/src/main/java/com/dnd/reetplace/app/service/BookmarkService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/BookmarkService.java
@@ -7,8 +7,11 @@ import com.dnd.reetplace.app.dto.place.PlaceDto;
 import com.dnd.reetplace.app.repository.BookmarkRepository;
 import com.dnd.reetplace.app.repository.MemberRepository;
 import com.dnd.reetplace.app.repository.PlaceRepository;
+import com.dnd.reetplace.app.type.BookmarkSearchType;
 import com.dnd.reetplace.global.exception.member.MemberIdNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +42,24 @@ public class BookmarkService {
         return BookmarkDto.from(
                 bookmarkRepository.save(bookmarkDto.toEntity(member, place))
         );
+    }
+
+    /**
+     * 북마크 리스트를 검색한다.
+     *
+     * @param memberId 북마크 리스트를 검색하고자 하는 로그인 회원
+     * @param searchType 검색하고자 하는 북마크 리스트의 종류 (전체, 가고 싶어요, 갔다 왔어요)
+     * @param pageable paging 정보
+     * @return 북마크 정보가 담긴 {@link Slice} 객체
+     */
+    public Slice<BookmarkDto> searchBookmarks(Long memberId, BookmarkSearchType searchType, Pageable pageable) {
+        if (searchType.equals(BookmarkSearchType.ALL)) {
+            return bookmarkRepository.findByMember_Id(memberId, pageable)
+                    .map(BookmarkDto::from);
+        }
+
+        return bookmarkRepository.findByTypeAndMember_Id(searchType.toBookmarkType(), memberId, pageable)
+                .map(BookmarkDto::from);
     }
 
     /**

--- a/src/main/java/com/dnd/reetplace/app/type/BookmarkSearchSort.java
+++ b/src/main/java/com/dnd/reetplace/app/type/BookmarkSearchSort.java
@@ -1,0 +1,14 @@
+package com.dnd.reetplace.app.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum BookmarkSearchSort {
+
+    LATEST("최신순"),
+    POPULARITY("인기순");
+
+    private final String description;
+}

--- a/src/main/java/com/dnd/reetplace/app/type/BookmarkSearchType.java
+++ b/src/main/java/com/dnd/reetplace/app/type/BookmarkSearchType.java
@@ -1,0 +1,12 @@
+package com.dnd.reetplace.app.type;
+
+import lombok.Getter;
+
+@Getter
+public enum BookmarkSearchType {
+    ALL, WANT, GONE;
+
+    public BookmarkType toBookmarkType() {
+        return BookmarkType.valueOf(this.name());
+    }
+}

--- a/src/test/java/com/dnd/reetplace/unit/app/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/dnd/reetplace/unit/app/controller/BookmarkControllerTest.java
@@ -14,6 +14,7 @@ import com.dnd.reetplace.app.dto.member.MemberDto;
 import com.dnd.reetplace.app.dto.place.PlaceDto;
 import com.dnd.reetplace.app.dto.place.request.PlaceRequest;
 import com.dnd.reetplace.app.service.BookmarkService;
+import com.dnd.reetplace.app.type.BookmarkSearchType;
 import com.dnd.reetplace.app.type.BookmarkType;
 import com.dnd.reetplace.app.type.LoginType;
 import com.dnd.reetplace.app.type.PlaceCategoryGroupCode;
@@ -27,6 +28,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -39,6 +42,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -86,6 +90,25 @@ class BookmarkControllerTest {
                 )
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(expectedBookmarkId));
+    }
+
+    @DisplayName("")
+    @Test
+    void givenSearchConditions_whenSearching_thenReturnBookmarksSlice() throws Exception {
+        // given
+        Long memberId = 1L;
+        given(bookmarkService.searchBookmarks(memberId, BookmarkSearchType.ALL, Pageable.ofSize(20)))
+                .willReturn(Page.empty());
+
+        // when & then
+        mvc.perform(
+                        get("/api/bookmarks/list")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .param("searchType", "ALL")
+                                .with(csrf())
+                                .with(user(new MemberDetails(createMember())))
+                )
+                .andExpect(status().isOk());
     }
 
     private Member createMember() {

--- a/src/test/java/com/dnd/reetplace/unit/app/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/dnd/reetplace/unit/app/controller/BookmarkControllerTest.java
@@ -14,10 +14,7 @@ import com.dnd.reetplace.app.dto.member.MemberDto;
 import com.dnd.reetplace.app.dto.place.PlaceDto;
 import com.dnd.reetplace.app.dto.place.request.PlaceRequest;
 import com.dnd.reetplace.app.service.BookmarkService;
-import com.dnd.reetplace.app.type.BookmarkSearchType;
-import com.dnd.reetplace.app.type.BookmarkType;
-import com.dnd.reetplace.app.type.LoginType;
-import com.dnd.reetplace.app.type.PlaceCategoryGroupCode;
+import com.dnd.reetplace.app.type.*;
 import com.dnd.reetplace.global.security.JwtAuthenticationFilter;
 import com.dnd.reetplace.global.security.MemberDetails;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -97,18 +94,20 @@ class BookmarkControllerTest {
     void givenSearchConditions_whenSearching_thenReturnBookmarksSlice() throws Exception {
         // given
         Long memberId = 1L;
-        given(bookmarkService.searchBookmarks(memberId, BookmarkSearchType.ALL, Pageable.ofSize(20)))
-                .willReturn(Page.empty());
+        given(bookmarkService.searchBookmarks(
+                memberId,
+                BookmarkSearchType.ALL,
+                BookmarkSearchSort.LATEST,
+                Pageable.ofSize(20))
+        ).willReturn(Page.empty());
 
         // when & then
-        mvc.perform(
-                        get("/api/bookmarks/list")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .param("searchType", "ALL")
-                                .with(csrf())
-                                .with(user(new MemberDetails(createMember())))
-                )
-                .andExpect(status().isOk());
+        mvc.perform(get("/api/bookmarks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("searchType", "ALL")
+                .with(csrf())
+                .with(user(new MemberDetails(createMember())))
+        ).andExpect(status().isOk());
     }
 
     private Member createMember() {

--- a/src/test/java/com/dnd/reetplace/unit/app/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/dnd/reetplace/unit/app/controller/BookmarkControllerTest.java
@@ -89,7 +89,7 @@ class BookmarkControllerTest {
                 .andExpect(jsonPath("$.id").value(expectedBookmarkId));
     }
 
-    @DisplayName("")
+    @DisplayName("주어진 검색 정보/조건으로 검색을 하면 북마크 목록을 반환한다.")
     @Test
     void givenSearchConditions_whenSearching_thenReturnBookmarksSlice() throws Exception {
         // given

--- a/src/test/java/com/dnd/reetplace/unit/app/service/BookmarkServiceTest.java
+++ b/src/test/java/com/dnd/reetplace/unit/app/service/BookmarkServiceTest.java
@@ -9,10 +9,7 @@ import com.dnd.reetplace.app.repository.BookmarkRepository;
 import com.dnd.reetplace.app.repository.MemberRepository;
 import com.dnd.reetplace.app.repository.PlaceRepository;
 import com.dnd.reetplace.app.service.BookmarkService;
-import com.dnd.reetplace.app.type.BookmarkSearchType;
-import com.dnd.reetplace.app.type.BookmarkType;
-import com.dnd.reetplace.app.type.LoginType;
-import com.dnd.reetplace.app.type.PlaceCategoryGroupCode;
+import com.dnd.reetplace.app.type.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -105,15 +102,16 @@ class BookmarkServiceTest {
     void givenSearchTypeAll_whenSearchingBookmarks_thenReturnBookmarkSlice() {
         // given
         Long memberId = 1L;
+        BookmarkSearchSort sort = BookmarkSearchSort.LATEST;
         Pageable pageable = Pageable.ofSize(20);
         PageImpl<Bookmark> expectedBookmarks = new PageImpl<>(List.of(createBookmark(createMember(), createPlace())));
-        given(bookmarkRepository.findByMember_Id(memberId, pageable)).willReturn(expectedBookmarks);
+        given(bookmarkRepository.findByMember_IdOrderByCreatedAtDesc(memberId, pageable)).willReturn(expectedBookmarks);
 
         // when
-        Slice<BookmarkDto> actualBookmarks = sut.searchBookmarks(memberId, BookmarkSearchType.ALL, pageable);
+        Slice<BookmarkDto> actualBookmarks = sut.searchBookmarks(memberId, BookmarkSearchType.ALL, sort, pageable);
 
         // then
-        then(bookmarkRepository).should().findByMember_Id(memberId, pageable);
+        then(bookmarkRepository).should().findByMember_IdOrderByCreatedAtDesc(memberId, pageable);
         then(bookmarkRepository).shouldHaveNoMoreInteractions();
         assertThat(actualBookmarks.getContent().get(0).getId())
                 .isEqualTo(expectedBookmarks.getContent().get(0).getId());
@@ -125,16 +123,17 @@ class BookmarkServiceTest {
         // given
         Long memberId = 1L;
         BookmarkSearchType searchType = BookmarkSearchType.WANT;
+        BookmarkSearchSort sort = BookmarkSearchSort.LATEST;
         Pageable pageable = Pageable.ofSize(20);
         PageImpl<Bookmark> expectedBookmarks = new PageImpl<>(List.of(createBookmark(createMember(), createPlace())));
-        given(bookmarkRepository.findByTypeAndMember_Id(searchType.toBookmarkType(), memberId, pageable))
+        given(bookmarkRepository.findByTypeAndMember_IdOrderByCreatedAtDesc(searchType.toBookmarkType(), memberId, pageable))
                 .willReturn(expectedBookmarks);
 
         // when
-        Slice<BookmarkDto> actualBookmarks = sut.searchBookmarks(memberId, searchType, pageable);
+        Slice<BookmarkDto> actualBookmarks = sut.searchBookmarks(memberId, searchType, sort, pageable);
 
         // then
-        then(bookmarkRepository).should().findByTypeAndMember_Id(searchType.toBookmarkType(), memberId, pageable);
+        then(bookmarkRepository).should().findByTypeAndMember_IdOrderByCreatedAtDesc(searchType.toBookmarkType(), memberId, pageable);
         assertThat(actualBookmarks.getContent().get(0).getId())
                 .isEqualTo(expectedBookmarks.getContent().get(0).getId());
     }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #44

## 🏃‍ Task
- 북마크 리스트 검색 기능 구현
  - 페이징 제공 
    - 모바일 환경이므로 `Page` 객체가 아닌 `Slice` 객체를 응답함.
    - 이렇게 함으로써 `Page` 객체로 조회할 때 발생하는 count query를 발생시키지 않는다. 모바일 환경에서 "전체 페이지 수"는 굳이 필요하지 않은 정보이므로 `Slice` 객체로 충분하다고 판단하였음.
  - 검색 조건 필터링 기능 제공 (전체 조회, "가고 싶어요", "갔다 왔어요" 조건 검색)

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?