### PR TITLE
검색기록 삭제 / 카테고리 필터 수정

### DIFF
--- a/src/main/java/com/dnd/reetplace/app/controller/PlaceController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/PlaceController.java
@@ -31,9 +31,10 @@ public class PlaceController {
             summary = "장소 목록 조회",
             description = "<p>사용자의 중심좌표를 기준으로 카테고리에 해당하는 장소목록을 조회합니다.</p>" +
                     "<ul>" +
-                    "<li>조회하고자 하는 카테고리를 모두 subCategory에 포함하여 요청합니다.</li>" +
                     "<li>로그인 한 사용자라면 Authorization 헤더에 Access Token을 포함하여 요청합니다.</li>" +
                     "<li>로그인 한 사용자라면 Access Token을 포함하여 요청 시 각 장소 별 북마크 여부를 확인할 수 있습니다.</li>" +
+                    "<li>로그인 한 사용자라면 subCategory를 포함하지 않습니다.</li>" +
+                    "<li>비로그인 사용자라면 조회하고자 하는 카테고리를 모두 subCategory에 포함하여 요청합니다.</li>" +
                     "</ul>"
     )
     @PostMapping

--- a/src/main/java/com/dnd/reetplace/app/controller/PlaceController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/PlaceController.java
@@ -1,15 +1,19 @@
 package com.dnd.reetplace.app.controller;
 
+import com.dnd.reetplace.app.dto.category.request.LikeCategoryUpdateRequest;
 import com.dnd.reetplace.app.dto.place.request.PlaceGetListRequest;
 import com.dnd.reetplace.app.dto.place.request.PlaceSearchRequest;
 import com.dnd.reetplace.app.dto.place.response.PlaceGetListResponse;
 import com.dnd.reetplace.app.dto.place.response.PlaceSearchListResponse;
 import com.dnd.reetplace.app.service.PlaceService;
+import com.dnd.reetplace.global.security.MemberDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -55,5 +59,18 @@ public class PlaceController {
             HttpServletRequest httpServletRequest,
             @Valid @RequestBody PlaceSearchRequest request) {
         return ResponseEntity.ok(placeService.searchPlace(httpServletRequest, request));
+    }
+
+    @Operation(
+            summary = "카테고리 필터 수정",
+            description = "로그인한 사용자의 카테고리 필터를 수정합니다. 상위 카테고리에 해당하는 하위 카테고리를 아무것도 선택하지 않았을 시 빈 배열을 넘깁니다. ex) subcategory: []",
+            security = @SecurityRequirement(name = "Authorization")
+    )
+    @PutMapping("/category")
+    public ResponseEntity<Void> updateLikeCategory(
+            @Parameter(hidden = true) @AuthenticationPrincipal MemberDetails memberDetails,
+            @Valid @RequestBody LikeCategoryUpdateRequest request) {
+        placeService.updateLikeCategory(memberDetails.getId(), request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/dnd/reetplace/app/controller/SearchController.java
+++ b/src/main/java/com/dnd/reetplace/app/controller/SearchController.java
@@ -10,9 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "검색", description = "검색 관련 API입니다.")
 @RequiredArgsConstructor
@@ -36,5 +34,35 @@ public class SearchController {
             @Parameter(hidden = true) @AuthenticationPrincipal MemberDetails memberDetails
     ) {
         return ResponseEntity.ok(searchService.getSearchHistory(memberDetails.getId()));
+    }
+
+    @Operation(
+            summary = "검색기록 삭제 (단건)",
+            description = "로그인한 사용자의 검색기록을 삭제합니다.",
+            security = @SecurityRequirement(name = "Authorization")
+    )
+    @DeleteMapping("/history/{searchId}")
+    public ResponseEntity<Void> deleteSearchHistory(
+            @Parameter(hidden = true) @AuthenticationPrincipal MemberDetails memberDetails,
+            @Parameter(
+                    description = "삭제하고자 하는 검색기록의 id",
+                    example = "1"
+            ) @PathVariable Long searchId
+    ) {
+        searchService.deleteSearchHistory(memberDetails.getId(), searchId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(
+            summary = "검색기록 삭제 (전체)",
+            description = "로그인한 사용자의 검색기록을 삭제합니다.",
+            security = @SecurityRequirement(name = "Authorization")
+    )
+    @DeleteMapping("/history")
+    public ResponseEntity<Void> deleteAllSearchHistory(
+            @Parameter(hidden = true) @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        searchService.deleteAllSearchHistory(memberDetails.getId());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/dnd/reetplace/app/domain/LikeCategory.java
+++ b/src/main/java/com/dnd/reetplace/app/domain/LikeCategory.java
@@ -1,0 +1,53 @@
+package com.dnd.reetplace.app.domain;
+
+import com.dnd.reetplace.app.domain.common.BaseTimeEntity;
+import com.dnd.reetplace.app.domain.place.PlaceCategory;
+import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
+import com.dnd.reetplace.app.type.LoginType;
+import com.dnd.reetplace.global.converter.LikeSubCategoryConverter;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@SQLDelete(sql = "UPDATE like_category SET deleted_at = CURRENT_TIMESTAMP WHERE like_category_id = ?")
+@Entity
+public class LikeCategory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_category_id")
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PlaceCategory category;
+
+    @Column(nullable = false)
+    @Convert(converter = LikeSubCategoryConverter.class)
+    private List<PlaceSubCategory> subCategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    private LocalDateTime deletedAt;
+
+    @Builder
+    private LikeCategory(PlaceCategory category, List<PlaceSubCategory> subCategory, Member member) {
+        this.category = category;
+        this.subCategory = subCategory;
+        this.member = member;
+    }
+
+    public void updateSubCategory(List<PlaceSubCategory> subCategory) {
+        this.subCategory = subCategory;
+    }
+}

--- a/src/main/java/com/dnd/reetplace/app/dto/category/LikeCategoryDto.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/category/LikeCategoryDto.java
@@ -1,0 +1,35 @@
+package com.dnd.reetplace.app.dto.category;
+
+import com.dnd.reetplace.app.domain.LikeCategory;
+import com.dnd.reetplace.app.domain.place.*;
+import com.dnd.reetplace.app.dto.member.MemberDto;
+import com.dnd.reetplace.app.type.PlaceCategoryGroupCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class LikeCategoryDto {
+
+    private Long id;
+    private PlaceCategory category;
+    private List<PlaceSubCategory> subCategory;
+    private MemberDto member;
+
+    public static LikeCategoryDto from(LikeCategory entity) {
+        return of(
+                entity.getId(),
+                entity.getCategory(),
+                entity.getSubCategory(),
+                MemberDto.from(entity.getMember())
+        );
+    }
+
+    public static LikeCategoryDto of(Long id, PlaceCategory category, List<PlaceSubCategory> subCategory, MemberDto member) {
+        return new LikeCategoryDto(id, category, subCategory, member);
+    }
+}

--- a/src/main/java/com/dnd/reetplace/app/dto/category/request/LikeCategoryRequest.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/category/request/LikeCategoryRequest.java
@@ -1,0 +1,34 @@
+package com.dnd.reetplace.app.dto.category.request;
+
+import com.dnd.reetplace.app.domain.LikeCategory;
+import com.dnd.reetplace.app.domain.Member;
+import com.dnd.reetplace.app.domain.place.PlaceCategory;
+import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class LikeCategoryRequest {
+
+    @Schema(description = "상위 카테고리", example = "ACTIVITY")
+    @NotBlank
+    private PlaceCategory category;
+
+    @Schema(description = "하위 카테고리 목록", type = "list", example = "[\"ACTIVITY_PC\", \"ACTIVITY_KARAOKE\", \"ACTIVITY_PARK\"]")
+    @NotNull
+    private List<PlaceSubCategory> subCategory;
+
+    public LikeCategory toEntity(Member member) {
+        return LikeCategory.builder()
+                .category(category)
+                .subCategory(subCategory)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/dnd/reetplace/app/dto/category/request/LikeCategoryUpdateRequest.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/category/request/LikeCategoryUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.dnd.reetplace.app.dto.category.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class LikeCategoryUpdateRequest {
+    List<LikeCategoryRequest> contents;
+}

--- a/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceGetListRequest.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/request/PlaceGetListRequest.java
@@ -77,6 +77,9 @@ public class PlaceGetListRequest {
             "<li>CONCERT - 공연장,연극극장</li>" +
             "</ul>",
             type = "list", example = "[\"ACTIVITY_PC\", \"ACTIVITY_KARAOKE\", \"ACTIVITY_PARK\"]")
-    @NotEmpty
     private List<PlaceSubCategory> subCategory;
+
+    public void updateSubCategoryForLoginMember(List<PlaceSubCategory> subCategory) {
+        this.subCategory = subCategory;
+    }
 }

--- a/src/main/java/com/dnd/reetplace/app/dto/place/response/KakaoPlaceSearchListResponse.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/response/KakaoPlaceSearchListResponse.java
@@ -6,5 +6,6 @@ import java.util.List;
 
 @Getter
 public class KakaoPlaceSearchListResponse {
+    private Meta meta;
     private List<KakaoPlaceSearchResponse> documents;
 }

--- a/src/main/java/com/dnd/reetplace/app/dto/place/response/KakaoPlaceSearchResponse.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/response/KakaoPlaceSearchResponse.java
@@ -1,19 +1,23 @@
 package com.dnd.reetplace.app.dto.place.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@JsonNaming(SnakeCaseStrategy.class)
 @Getter
 public class KakaoPlaceSearchResponse {
-    private String address_name;
-    private String category_group_code;
-    private String category_group_name;
-    private String category_name;
+    private String addressName;
+    private String categoryGroupCode;
+    private String categoryGroupName;
+    private String categoryName;
     private String distance;
     private String id;
     private String phone;
-    private String place_name;
-    private String place_url;
-    private String road_address_name;
+    private String placeName;
+    private String placeUrl;
+    private String roadAddressName;
     private String x;
     private String y;
 }

--- a/src/main/java/com/dnd/reetplace/app/dto/place/response/Meta.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/response/Meta.java
@@ -1,0 +1,14 @@
+package com.dnd.reetplace.app.dto.place.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+public class Meta {
+    private int totalCount;
+    private int pageableCount;
+    private Boolean isEnd;
+    private SameName sameName;
+}

--- a/src/main/java/com/dnd/reetplace/app/dto/place/response/PlaceSearchListResponse.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/response/PlaceSearchListResponse.java
@@ -10,8 +10,9 @@ import java.util.List;
 @Getter
 public class PlaceSearchListResponse {
     private List<PlaceSearchResponse> contents;
+    private boolean lastPage;
 
-    public static PlaceSearchListResponse of(List<PlaceSearchResponse> contents) {
-        return new PlaceSearchListResponse(contents);
+    public static PlaceSearchListResponse of(List<PlaceSearchResponse> contents, boolean isEnd) {
+        return new PlaceSearchListResponse(contents, isEnd);
     }
 }

--- a/src/main/java/com/dnd/reetplace/app/dto/place/response/PlaceSearchResponse.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/response/PlaceSearchResponse.java
@@ -147,22 +147,22 @@ public class PlaceSearchResponse {
     ) {
         PlaceCategoryGroupCode categoryGroupCode;
         try {
-            categoryGroupCode = PlaceCategoryGroupCode.valueOf(kakaoResponse.getCategory_group_code());
+            categoryGroupCode = PlaceCategoryGroupCode.valueOf(kakaoResponse.getCategoryGroupCode());
         } catch (IllegalArgumentException | NullPointerException e) {
             categoryGroupCode = null;
         }
 
         PlaceSubCategory subCategory;
         PlaceCategory category;
-        if (kakaoResponse.getCategory_name().contains("멕시칸") || kakaoResponse.getCategory_name().contains("아시아")) {
+        if (kakaoResponse.getCategoryName().contains("멕시칸") || kakaoResponse.getCategoryName().contains("아시아")) {
             subCategory = PlaceSubCategory.WORLD;
             category = PlaceCategory.FOOD;
-        } else if (kakaoResponse.getCategory_name().contains("치킨")) {
+        } else if (kakaoResponse.getCategoryName().contains("치킨")) {
             subCategory = PlaceSubCategory.COOKING_BAR;
             category = PlaceCategory.FOOD;
         } else {
             subCategory = Arrays.stream(PlaceSubCategory.values())
-                    .filter(sub -> kakaoResponse.getCategory_name().contains(sub.getDescription()))
+                    .filter(sub -> kakaoResponse.getCategoryName().contains(sub.getDescription()))
                     .findFirst()
                     .orElse(null);
             category = subCategory == null ? null : subCategory.getMainCategory();
@@ -170,16 +170,16 @@ public class PlaceSearchResponse {
 
         return new PlaceSearchResponse(
                 kakaoResponse.getId(),
-                kakaoResponse.getPlace_name(),
-                kakaoResponse.getPlace_url(),
+                kakaoResponse.getPlaceName(),
+                kakaoResponse.getPlaceUrl(),
                 thumbnailImage,
                 categoryGroupCode,
-                kakaoResponse.getCategory_name(),
+                kakaoResponse.getCategoryName(),
                 category,
                 subCategory,
                 kakaoResponse.getPhone(),
-                kakaoResponse.getAddress_name(),
-                kakaoResponse.getRoad_address_name(),
+                kakaoResponse.getAddressName(),
+                kakaoResponse.getRoadAddressName(),
                 kakaoResponse.getY(),
                 kakaoResponse.getX(),
                 bookmarkType,

--- a/src/main/java/com/dnd/reetplace/app/dto/place/response/SameName.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/response/SameName.java
@@ -1,0 +1,15 @@
+package com.dnd.reetplace.app.dto.place.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+
+@JsonNaming(SnakeCaseStrategy.class)
+@Getter
+public class SameName {
+    private String[] region;
+    private String keyword;
+    private String selectedRegion;
+}

--- a/src/main/java/com/dnd/reetplace/app/dto/search/SearchDto.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/search/SearchDto.java
@@ -13,14 +13,15 @@ import java.time.LocalDateTime;
 public class SearchDto {
 
     private MemberDto member;
+    private Long id;
     private String query;
     private LocalDateTime createdAt;
 
     public static SearchDto from(Search entity) {
-        return of(MemberDto.from(entity.getMember()), entity.getQuery(), entity.getCreatedAt());
+        return of(MemberDto.from(entity.getMember()), entity.getId(), entity.getQuery(), entity.getCreatedAt());
     }
 
-    public static SearchDto of(MemberDto member, String query, LocalDateTime createdAt) {
-        return new SearchDto(member, query, createdAt);
+    public static SearchDto of(MemberDto member, Long id, String query, LocalDateTime createdAt) {
+        return new SearchDto(member, id, query, createdAt);
     }
 }

--- a/src/main/java/com/dnd/reetplace/app/dto/search/response/SearchHistoryResponse.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/search/response/SearchHistoryResponse.java
@@ -12,6 +12,9 @@ import java.time.LocalDateTime;
 @Getter
 public class SearchHistoryResponse {
 
+    @Schema(description = "검색기록 id", example = "1")
+    private Long id;
+
     @Schema(description = "검색 키워드", example = "어글리 베이커리")
     private String query;
 
@@ -19,6 +22,6 @@ public class SearchHistoryResponse {
     private LocalDateTime createdAt;
 
     public static SearchHistoryResponse of(SearchDto search) {
-        return new SearchHistoryResponse(search.getQuery(), search.getCreatedAt());
+        return new SearchHistoryResponse(search.getId(), search.getQuery(), search.getCreatedAt());
     }
 }

--- a/src/main/java/com/dnd/reetplace/app/repository/LikeCategoryRepository.java
+++ b/src/main/java/com/dnd/reetplace/app/repository/LikeCategoryRepository.java
@@ -1,0 +1,14 @@
+package com.dnd.reetplace.app.repository;
+
+import com.dnd.reetplace.app.domain.LikeCategory;
+import com.dnd.reetplace.app.domain.place.PlaceCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface LikeCategoryRepository extends JpaRepository<LikeCategory, Long> {
+
+    @Query("select lc from LikeCategory lc where lc.member.id = :memberId and lc.category = :category")
+    Optional<LikeCategory> findByMemberIdAndCategory(Long memberId, PlaceCategory category);
+}

--- a/src/main/java/com/dnd/reetplace/app/repository/SearchRepository.java
+++ b/src/main/java/com/dnd/reetplace/app/repository/SearchRepository.java
@@ -2,9 +2,11 @@ package com.dnd.reetplace.app.repository;
 
 import com.dnd.reetplace.app.domain.Search;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SearchRepository extends JpaRepository<Search, Long>, SearchRepositoryCustom {
 
@@ -13,4 +15,11 @@ public interface SearchRepository extends JpaRepository<Search, Long>, SearchRep
 
     @Query("select s from Search s join fetch s.member m where s.member.id = :memberId and s.deletedAt is null")
     List<Search> findByMemberIdAndDeletedAtIsNull(Long memberId);
+
+    @Query("select s from Search s join fetch s.member m where s.id = :searchId and s.deletedAt is null")
+    Optional<Search> findByIdAndDeletedAtIsNull(Long searchId);
+
+    @Modifying
+    @Query("delete from Search s where s.member.id = :memberId and s.deletedAt is null")
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/dnd/reetplace/app/service/KakaoHttpRequestService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/KakaoHttpRequestService.java
@@ -122,7 +122,7 @@ public class KakaoHttpRequestService {
         }
     }
 
-    public List<KakaoPlaceSearchResponse> searchPlace(PlaceSearchRequest request) {
+    public KakaoPlaceSearchListResponse searchPlace(PlaceSearchRequest request) {
         try {
             // Header 추가
             HttpHeaders header = new HttpHeaders();
@@ -150,7 +150,7 @@ public class KakaoHttpRequestService {
                     httpRequest,
                     KakaoPlaceSearchListResponse.class
             );
-            return response.getBody().getDocuments();
+            return response.getBody();
         } catch (Exception e) {
             log.error("[{}] KakaoHttpRequestService.searchPlace() ex={}", LogUtils.getLogTraceId(), String.valueOf(e));
             throw new PlaceKakaoApiBadRequestException();

--- a/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
@@ -83,13 +83,14 @@ public class PlaceService {
      */
     @Transactional
     public PlaceSearchListResponse searchPlace(HttpServletRequest httpServletRequest, PlaceSearchRequest request) {
-        List<KakaoPlaceSearchResponse> result = kakaoHttpRequestService.searchPlace(request);
+        KakaoPlaceSearchListResponse result = kakaoHttpRequestService.searchPlace(request);
+        List<KakaoPlaceSearchResponse> documents = result.getDocuments();
         Member loginMember = findLoginMember(httpServletRequest);
-        List<PlaceSearchResponse> placeSearchWithBookmark = this.updateSearchPlaceIsBookmark(loginMember, result);
+        List<PlaceSearchResponse> placeSearchWithBookmark = this.updateSearchPlaceIsBookmark(loginMember, documents);
         if (loginMember != null) {
             this.updateSearchHistory(loginMember, request.getQuery());
         }
-        return PlaceSearchListResponse.of(placeSearchWithBookmark);
+        return PlaceSearchListResponse.of(placeSearchWithBookmark, result.getMeta().getIsEnd());
     }
 
     @Transactional

--- a/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
@@ -4,6 +4,7 @@ import com.dnd.reetplace.app.domain.LikeCategory;
 import com.dnd.reetplace.app.domain.Member;
 import com.dnd.reetplace.app.domain.Search;
 import com.dnd.reetplace.app.domain.bookmark.Bookmark;
+import com.dnd.reetplace.app.domain.place.PlaceCategory;
 import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
 import com.dnd.reetplace.app.dto.category.request.LikeCategoryUpdateRequest;
 import com.dnd.reetplace.app.dto.place.request.PlaceGetListRequest;
@@ -20,10 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 import static com.dnd.reetplace.app.domain.place.PlaceCategory.REET_PLACE_POPULAR;
 
@@ -55,11 +53,13 @@ public class PlaceService {
      * @param request            조회하고자 하는 장소 및 현재 위치에 대한 정보가 담긴 Request Dto
      * @return 카테고리에 해당하는 장소 목록 (로그인 시 북마크 여부 포함)
      */
-    public PlaceGetListResponse getPlaceList(
-            HttpServletRequest httpServletRequest,
-            PlaceGetListRequest request) {
+    public PlaceGetListResponse getPlaceList(HttpServletRequest httpServletRequest, PlaceGetListRequest request) {
+        Member loginMember = findLoginMember(httpServletRequest);
 
-        List<PlaceSubCategory> subCategory = request.getSubCategory();
+        // 로그인 여부에 따른 subCategory 처리
+        List<PlaceSubCategory> subCategory = loginMember == null ?
+                request.getSubCategory() : this.getSubCategoryForLoginMember(loginMember.getId(), request.getCategory());
+
         long size = Math.round(15.0 / subCategory.size());
 
         // 카카오 서버에서 받아온 장소 목록 collect
@@ -69,7 +69,7 @@ public class PlaceService {
                         getPlaceListFromKakao(request, subCategory, size);
 
         // 북마크 여부 처리
-        List<PlaceGetResponse> placeListWithBookmark = updateGetPlaceIsBookmark(httpServletRequest, result);
+        List<PlaceGetResponse> placeListWithBookmark = updateGetPlaceIsBookmark(loginMember, result);
         return PlaceGetListResponse.of(placeListWithBookmark);
     }
 
@@ -178,12 +178,11 @@ public class PlaceService {
      * (로그인 시) 장소 목록 조회에서 각 장소 별 북마크 여부 및 북마크 id를 업데이트한다.
      * 또한, 카카오에서 제공하는 장소 정보 -> 앱 내에서 필요한 정보만 포함하는 Custom Response로 결과를 변환하여 반환한다.
      *
-     * @param httpServletRequest 로그인 여부를 판단하기 위한 HttpServletRequest 객체
-     * @param result             카카오 로컬 API를 통해 받아온 카카오에서 제공하는 장소 정보 List
+     * @param loginMember 로그인 한 사용자 엔티티 (비로그인 사용자 경우 null)
+     * @param result      카카오 로컬 API를 통해 받아온 카카오에서 제공하는 장소 정보 List
      * @return 북마크 여부 및 북마크 id가 업데이트 된 Custom Place Response List
      */
-    private List<PlaceGetResponse> updateGetPlaceIsBookmark(HttpServletRequest httpServletRequest, List<KakaoPlaceGetResponse> result) {
-        Member loginMember = findLoginMember(httpServletRequest);
+    private List<PlaceGetResponse> updateGetPlaceIsBookmark(Member loginMember, List<KakaoPlaceGetResponse> result) {
         if (loginMember == null) {
             return result.stream()
                     .map(response -> PlaceGetResponse.ofWithoutBookmark(response, scrapService.getPlaceThumbnailUrl(response.getId())))
@@ -262,5 +261,15 @@ public class PlaceService {
     private Member validateLoginMember(Long memberId) {
         return memberRepository.findByIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new MemberIdNotFoundException(memberId));
+    }
+
+    private List<PlaceSubCategory> getSubCategoryForLoginMember(Long memberId, PlaceCategory category) {
+        Optional<LikeCategory> likeCategory = likeCategoryRepository.findByMemberIdAndCategory(memberId, category);
+        // likeCategory 존재할 경우 필터 설정 case로, 사용자 설정된 하위 카테고리 반환
+        if (likeCategory.isPresent() && !likeCategory.get().getSubCategory().isEmpty()) {
+            return likeCategory.get().getSubCategory();
+        }
+        // likeCategory 존재하지 않거나 subCategory 비어있을 경우 전체 선택 case로, 상위 카테고리에 해당하는 모든 하위 카테고리 반환
+        return Arrays.stream(PlaceSubCategory.values()).filter(c -> c.getMainCategory().equals(category)).toList();
     }
 }

--- a/src/main/java/com/dnd/reetplace/app/service/SearchService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/SearchService.java
@@ -1,8 +1,16 @@
 package com.dnd.reetplace.app.service;
 
+import com.dnd.reetplace.app.domain.Member;
+import com.dnd.reetplace.app.domain.Search;
 import com.dnd.reetplace.app.dto.search.SearchDto;
 import com.dnd.reetplace.app.dto.search.response.SearchHistoryListResponse;
+import com.dnd.reetplace.app.repository.MemberRepository;
 import com.dnd.reetplace.app.repository.SearchRepository;
+import com.dnd.reetplace.app.type.LoginType;
+import com.dnd.reetplace.global.exception.member.MemberIdNotFoundException;
+import com.dnd.reetplace.global.exception.member.MemberUidNotFoundException;
+import com.dnd.reetplace.global.exception.search.SearchDeletePermissionDeniedException;
+import com.dnd.reetplace.global.exception.search.SearchIdNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +23,7 @@ import java.util.List;
 public class SearchService {
 
     private final SearchRepository searchRepository;
+    private final MemberRepository memberRepository;
 
     /**
      * memberId에 해당하는 로그인 사용자의 검색 기록을 조회한다.
@@ -28,5 +37,44 @@ public class SearchService {
                 .map(SearchDto::from)
                 .toList();
         return SearchHistoryListResponse.of(searchDtoList);
+    }
+
+    public void deleteSearchHistory(Long memberId, Long searchId) {
+        // 사용자 유효성 검사
+        this.validateLoginMember(memberId);
+        // 검색기록 조회
+        Search search = this.getSearch(searchId);
+        // 검색기록 삭제 권한 확인
+        this.validateSearchDeletePermission(memberId, search);
+        // 검색기록 삭제
+        searchRepository.delete(search);
+    }
+
+    public void deleteAllSearchHistory(Long memberId) {
+        // 사용자 유효성 검사
+        this.validateLoginMember(memberId);
+        // 검색기록 삭제
+        searchRepository.deleteAllByMemberId(memberId);
+    }
+
+    private Search getSearch(Long searchId) {
+        return searchRepository.findByIdAndDeletedAtIsNull(searchId)
+                .orElseThrow(() -> new SearchIdNotFoundException(searchId));
+    }
+
+    private void validateSearchDeletePermission(Long memberId, Search search) {
+        if (!search.getMember().getId().equals(memberId)) {
+            throw new SearchDeletePermissionDeniedException();
+        }
+    }
+
+    /**
+     * memberId를 통해 사용자 유효성을 검사한다.
+     *
+     * @param memberId 사용자 id
+     */
+    private void validateLoginMember(Long memberId) {
+        memberRepository.findByIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new MemberIdNotFoundException(memberId));
     }
 }

--- a/src/main/java/com/dnd/reetplace/app/service/SearchService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/SearchService.java
@@ -39,6 +39,7 @@ public class SearchService {
         return SearchHistoryListResponse.of(searchDtoList);
     }
 
+    @Transactional
     public void deleteSearchHistory(Long memberId, Long searchId) {
         // 사용자 유효성 검사
         this.validateLoginMember(memberId);
@@ -50,6 +51,7 @@ public class SearchService {
         searchRepository.delete(search);
     }
 
+    @Transactional
     public void deleteAllSearchHistory(Long memberId) {
         // 사용자 유효성 검사
         this.validateLoginMember(memberId);

--- a/src/main/java/com/dnd/reetplace/global/converter/LikeSubCategoryConverter.java
+++ b/src/main/java/com/dnd/reetplace/global/converter/LikeSubCategoryConverter.java
@@ -1,0 +1,26 @@
+package com.dnd.reetplace.global.converter;
+
+import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Converter
+public class LikeSubCategoryConverter implements AttributeConverter<List<PlaceSubCategory>, String> {
+
+    public static final String EMPTY_STRING = "";
+
+    @Override
+    public String convertToDatabaseColumn(List<PlaceSubCategory> attribute) {
+        return attribute.isEmpty() ? EMPTY_STRING : attribute.stream().map(PlaceSubCategory::name).collect(Collectors.joining(","));
+    }
+
+    @Override
+    public List<PlaceSubCategory> convertToEntityAttribute(String dbData) {
+        return dbData.isBlank() ? Collections.emptyList() : Arrays.stream(dbData.split(",")).map(PlaceSubCategory::valueOf).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dnd/reetplace/global/exception/ExceptionType.java
+++ b/src/main/java/com/dnd/reetplace/global/exception/ExceptionType.java
@@ -10,6 +10,8 @@ import com.dnd.reetplace.global.exception.member.MemberIdNotFoundException;
 import com.dnd.reetplace.global.exception.member.MemberUidNotFoundException;
 import com.dnd.reetplace.global.exception.place.PlaceKakaoApiBadRequestException;
 import com.dnd.reetplace.global.exception.place.PlaceKakaoPidNotFoundException;
+import com.dnd.reetplace.global.exception.search.SearchDeletePermissionDeniedException;
+import com.dnd.reetplace.global.exception.search.SearchIdNotFoundException;
 import com.dnd.reetplace.global.exception.type.ValidationErrorCode;
 import com.dnd.reetplace.global.log.LogUtils;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -54,6 +56,7 @@ import java.util.Optional;
  *     <li>4000 ~ 4999: 파일 업로드({@link S3File}) 관련 예외</li>
  *     <li>5000 ~ 5499: 문의({@link Question}) 관련 예외</li>
  *     <li>5500 ~ 5999: 문의 답변({@link Answer}) 관련 예외</li>
+ *     <li>6000 ~ 6499: 검색기록({@link Search}) 관련 예외</li>
  * </ul>
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -126,7 +129,11 @@ public enum ExceptionType {
 
     // Place
     PLACE_KAKAO_PID_NOT_FOUND_EXCEPTION(3500, "장소를 찾을 수 없습니다.", PlaceKakaoPidNotFoundException.class),
-    PLACE_KAKAO_API_BAD_REQUEST_EXCEPTION(3501, "장소 조회에 실패했습니다. 올바른 파라미터를 입력했는지 확인해주세요.", PlaceKakaoApiBadRequestException.class);
+    PLACE_KAKAO_API_BAD_REQUEST_EXCEPTION(3501, "장소 조회에 실패했습니다. 올바른 파라미터를 입력했는지 확인해주세요.", PlaceKakaoApiBadRequestException.class),
+
+    // Search
+    SEARCH_ID_NOT_FOUND(6000, "ID에 해당하는 검색기록을 찾을 수 없습니다.", SearchIdNotFoundException.class),
+    SEARCH_DELETE_PERMISSION_DENIED(6001, "검색기록을 삭제할 수 있는 권한이 없습니다.", SearchDeletePermissionDeniedException.class);
 
     private final Integer code;
     private final String message;

--- a/src/main/java/com/dnd/reetplace/global/exception/search/SearchDeletePermissionDeniedException.java
+++ b/src/main/java/com/dnd/reetplace/global/exception/search/SearchDeletePermissionDeniedException.java
@@ -1,0 +1,6 @@
+package com.dnd.reetplace.global.exception.search;
+
+import com.dnd.reetplace.global.exception.common.ForbiddenException;
+
+public class SearchDeletePermissionDeniedException extends ForbiddenException {
+}

--- a/src/main/java/com/dnd/reetplace/global/exception/search/SearchIdNotFoundException.java
+++ b/src/main/java/com/dnd/reetplace/global/exception/search/SearchIdNotFoundException.java
@@ -1,0 +1,15 @@
+package com.dnd.reetplace.global.exception.search;
+
+import com.dnd.reetplace.global.exception.common.NotFoundException;
+
+public class SearchIdNotFoundException extends NotFoundException {
+
+    /**
+     * 찾지 못한 검색기록에 해당하는 id를 출력한다.
+     *
+     * @param searchId 조회시도 한 검색기록 id
+     */
+    public SearchIdNotFoundException(Long searchId) {
+        super("searchId = " + searchId);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ spring:
     password: ${REET_PLACE_LOCAL_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
-    hibernate.ddl-auto: create
+    hibernate.ddl-auto: none
     defer-datasource-initialization: true
   sql.init.mode: always
 

--- a/src/test/java/com/dnd/reetplace/integration/app/service/SearchIntegrationTest.java
+++ b/src/test/java/com/dnd/reetplace/integration/app/service/SearchIntegrationTest.java
@@ -8,6 +8,9 @@ import com.dnd.reetplace.app.repository.SearchRepository;
 import com.dnd.reetplace.app.service.PlaceService;
 import com.dnd.reetplace.app.service.SearchService;
 import com.dnd.reetplace.app.type.LoginType;
+import com.dnd.reetplace.global.exception.member.MemberIdNotFoundException;
+import com.dnd.reetplace.global.exception.search.SearchDeletePermissionDeniedException;
+import com.dnd.reetplace.global.exception.search.SearchIdNotFoundException;
 import com.dnd.reetplace.global.security.TokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,13 +24,14 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Transactional
 @SpringBootTest
 public class SearchIntegrationTest {
 
     @Autowired
-    SearchService searchService;
+    SearchService sut;
 
     @Autowired
     MemberRepository memberRepository;
@@ -63,7 +67,7 @@ public class SearchIntegrationTest {
         }
 
         // when
-        SearchHistoryListResponse result = searchService.getSearchHistory(savedMember.getId());
+        SearchHistoryListResponse result = sut.getSearchHistory(savedMember.getId());
         List<Search> all = searchRepository.findAll();
 
 
@@ -74,6 +78,99 @@ public class SearchIntegrationTest {
         assertThat(all.stream().map(Search::getQuery).anyMatch(q -> q.equals("test2"))).isTrue();
     }
 
+    @DisplayName("검색기록 삭제(단건)에 성공한다.")
+    @Test
+    void whenDeleteSearchHistory_thenSuccess() {
+        // given
+        Member savedMember = memberRepository.save(createMember(1L));
+        login(savedMember);
+        Search savedSearch = Search.builder()
+                .member(savedMember) // 검색기록 저장
+                .query("test")
+                .build();
+        searchRepository.save(savedSearch);
+
+        // when
+        sut.deleteSearchHistory(savedMember.getId(), savedSearch.getId());
+
+        // then
+        assertThat(searchRepository.findByMemberIdAndDeletedAtIsNull(savedMember.getId())).isEmpty();
+    }
+
+    @DisplayName("검색기록 삭제 시 존재하지 않는 사용자면 실패한다.")
+    @Test
+    void whenDeleteSearchHistoryWithNotExistsMember_thenFail() {
+        // given
+        Member savedMember = memberRepository.save(createMember(1L));
+        login(savedMember);
+        Search savedSearch = Search.builder()
+                .member(savedMember) // 검색기록 저장
+                .query("test")
+                .build();
+        searchRepository.save(savedSearch);
+
+        // when & then
+        assertThrows(MemberIdNotFoundException.class,
+                () -> sut.deleteSearchHistory(savedMember.getId() + 1L, savedSearch.getId())); // 존재하지 않는 사용자
+    }
+
+    @DisplayName("검색기록 삭제(단건) 시 존재하지 않는 검색기록이면 실패한다.")
+    @Test
+    void whenDeleteSearchHistoryWithNotExistsSearch_thenFail() {
+        // given
+        Member savedMember = memberRepository.save(createMember(1L));
+        login(savedMember);
+        Search savedSearch = Search.builder()
+                .member(savedMember) // 검색기록 저장
+                .query("test")
+                .build();
+        searchRepository.save(savedSearch);
+
+        // when & then
+        assertThrows(SearchIdNotFoundException.class,
+                () -> sut.deleteSearchHistory(savedMember.getId(), savedSearch.getId() + 1)); // 존재하지 않는 검색기록
+    }
+
+    @DisplayName("검색기록 삭제(단건) 시 자신의 검색기록이 아니면 실패한다.")
+    @Test
+    void whenDeleteSearchHistoryWithNotSearchHistoryOwner_thenFail() {
+        // given
+        Member savedMember1 = memberRepository.save(createMember(1L));
+        Member savedMember2 = memberRepository.save(createMember(2L));
+        login(savedMember1); // 로그인 (member 1)
+        Search savedSearch = Search.builder()
+                .member(savedMember2) // 검색기록 저장 (member 2)
+                .query("test")
+                .build();
+        searchRepository.save(savedSearch);
+
+        // when & then
+        assertThrows(SearchDeletePermissionDeniedException.class,
+                () -> sut.deleteSearchHistory(savedMember1.getId(), savedSearch.getId())); // 타 사용자의 검색기록 삭제 요청
+    }
+
+    @DisplayName("검색기록 삭제(전체)에 성공한다.")
+    @Test
+    void whenDeleteAllSearchHistory_thenSuccess() {
+        // given
+        Member savedMember = memberRepository.save(createMember(1L));
+        login(savedMember);
+        for (int i = 0; i < 5; i++) {
+            // 검색기록 저장
+            Search search = Search.builder()
+                    .member(savedMember)
+                    .query("test" + i)
+                    .build();
+            searchRepository.save(search);
+        }
+
+        // when
+        sut.deleteAllSearchHistory(savedMember.getId());
+
+        // then
+        assertThat(searchRepository.findByMemberIdAndDeletedAtIsNull(savedMember.getId())).isEmpty();
+    }
+
     private void login(Member member) {
         String accessToken = tokenProvider.createAccessToken(member.getUid(), member.getLoginType());
         Authentication authToken = tokenProvider.getAuthentication(accessToken);
@@ -82,9 +179,9 @@ public class SearchIntegrationTest {
 
     private Member createMember(Long memberId) {
         Member member = Member.builder()
-                .uid("test")
+                .uid("test" + memberId)
                 .loginType(LoginType.KAKAO)
-                .nickname("test")
+                .nickname("test" + memberId)
                 .build();
         ReflectionTestUtils.setField(member, "id", memberId);
 

--- a/src/test/java/com/dnd/reetplace/unit/app/service/SearchServiceTest.java
+++ b/src/test/java/com/dnd/reetplace/unit/app/service/SearchServiceTest.java
@@ -3,6 +3,7 @@ package com.dnd.reetplace.unit.app.service;
 import com.dnd.reetplace.app.domain.Member;
 import com.dnd.reetplace.app.domain.Search;
 import com.dnd.reetplace.app.dto.search.response.SearchHistoryListResponse;
+import com.dnd.reetplace.app.repository.MemberRepository;
 import com.dnd.reetplace.app.repository.SearchRepository;
 import com.dnd.reetplace.app.service.SearchService;
 import com.dnd.reetplace.app.type.LoginType;
@@ -15,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -27,6 +29,9 @@ class SearchServiceTest {
 
     @Mock
     private SearchRepository searchRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
 
     @DisplayName("검색기록 조회에 성공한다.")
     @Test
@@ -48,6 +53,20 @@ class SearchServiceTest {
         assertThat(result.getContents().get(0).getQuery()).isEqualTo(searchList.get(0).getQuery());
         assertThat(result.getContents().get(1).getQuery()).isEqualTo(searchList.get(1).getQuery());
         assertThat(result.getContents().get(2).getQuery()).isEqualTo(searchList.get(2).getQuery());
+    }
+
+    @DisplayName("검색기록 삭제(단건)에 성공한다.")
+    @Test
+    void givenSearchId_whenDeleteSearchHistory_thenSuccess() {
+        // given
+        Member member = createMember(1L);
+        Search search = Search.builder().query("test").member(member).build();
+        ReflectionTestUtils.setField(search, "id", 1L);
+        given(memberRepository.findByIdAndDeletedAtIsNull(member.getId())).willReturn(Optional.of(member));
+        given(searchRepository.findByIdAndDeletedAtIsNull(search.getId())).willReturn(Optional.of(search));
+
+        // when & then
+        sut.deleteSearchHistory(member.getId(), search.getId());
     }
 
     private Member createMember(Long memberId) {


### PR DESCRIPTION
## 🔥 Related Issue
- Close #91 

## 🏃‍ Task
- 검색기록 삭제 API 구현 (단건)
- 검색기록 삭제 API 구현 (전체)
- 검색기록 삭제 테스트코드 작성
- 카테고리 필터 수정 API 구현
- 장소 목록 조회 시 DB 내 카테고리 필터 데이터 바라보도록 API 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?