### PR TITLE
릿플인기에 대해서 주소 표기 다르게 응답되는 현상 수정

### DIFF
--- a/src/main/java/com/dnd/reetplace/app/dto/place/response/KakaoPlaceGetResponse.java
+++ b/src/main/java/com/dnd/reetplace/app/dto/place/response/KakaoPlaceGetResponse.java
@@ -2,6 +2,7 @@ package com.dnd.reetplace.app.dto.place.response;
 
 import com.dnd.reetplace.app.domain.place.PlaceCategory;
 import com.dnd.reetplace.app.domain.place.PlaceSubCategory;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,6 +26,12 @@ public class KakaoPlaceGetResponse {
     private PlaceCategory category;
     private PlaceSubCategory subCategory;
 
+    // 내부 주소 파싱용 데이터
+    @JsonIgnore
+    private String sido;
+    @JsonIgnore
+    private String sgg;
+
     // Native Query 파싱을 위한 생성자 (JpaResultMapper)
     public KakaoPlaceGetResponse(
             String address_name,
@@ -36,6 +43,8 @@ public class KakaoPlaceGetResponse {
             String place_name,
             String place_url,
             String road_address_name,
+            String sido,
+            String sgg,
             String x,
             String y,
             String category,
@@ -51,6 +60,8 @@ public class KakaoPlaceGetResponse {
         this.place_name = place_name;
         this.place_url = place_url;
         this.road_address_name = road_address_name;
+        this.sido = sido;
+        this.sgg = sgg;
         this.x = x;
         this.y = y;
         this.category = PlaceCategory.valueOf(category);
@@ -90,5 +101,18 @@ public class KakaoPlaceGetResponse {
     public void updateCategory(PlaceCategory category, PlaceSubCategory subCategory) {
         this.category = category;
         this.subCategory = subCategory;
+    }
+
+    // DB 내 시도 / 시군구 단위 파싱되어 있는 주소체계 카카오 응답과 맞줌
+    public void parseAddress() {
+        if (sgg.isEmpty()) return;
+        int sggLength = sgg.split(" ").length;
+        if (sggLength == 1) {
+            if (sgg.charAt(sgg.length() - 1) == '구') {
+                this.road_address_name = sido + sgg + this.road_address_name;
+            } else {
+                this.road_address_name = sgg + this.road_address_name;
+            }
+        }
     }
 }

--- a/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
+++ b/src/main/java/com/dnd/reetplace/app/service/PlaceService.java
@@ -66,7 +66,7 @@ public class PlaceService {
         // 카카오 서버에서 받아온 장소 목록 collect
         List<KakaoPlaceGetResponse> result =
                 request.getCategory().equals(REET_PLACE_POPULAR) ?
-                        placeRepository.getReetPlacePopularPlaceList(request.getLat(), request.getLng()) :
+                        placeRepository.getReetPlacePopularPlaceList(request.getLat(), request.getLng()).stream().peek(KakaoPlaceGetResponse::parseAddress).toList() :
                         getPlaceListFromKakao(request, subCategory, size);
 
         // 북마크 여부 처리


### PR DESCRIPTION
## 🔥 Related Issue
- Close #115 

## 🏃‍ Task
- 릿플인기 address 응답 시 sido(시도) + sgg(시군구) + address(주소) 형태로 응답하도록 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?